### PR TITLE
[FEATURE] Add Github link to the site #7

### DIFF
--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -72,7 +72,7 @@ export const SideNavbar = () => {
         </div>
           <ul className="inline-flex space-x-2">
             <li>
-              <a title="Link to Github project" href="https://github.com/rupali-codes/LinksHub">
+              <a title="Link to Github project (External Link)" target="_blank" href="https://github.com/rupali-codes/LinksHub">
                 <IconContext.Provider value={{ className: "shared-class", size: "28" }}>
                   <FaGithub/>
                 </IconContext.Provider>

--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -23,7 +23,7 @@ export const SideNavbar = () => {
         </h1>
         <ul className="inline-flex space-x-2">
             <li>
-              <a title="Link to Github project (External Link)" target="_blank" href="https://github.com/rupali-codes/LinksHub">
+              <a title="Link to Github project (External Link)" target="_blank" rel="noopener noreferrer" href="https://github.com/rupali-codes/LinksHub">
                 <IconContext.Provider value={{ className: "shared-class", size: "28" }}>
                   <FaGithub/>
                 </IconContext.Provider>

--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -2,6 +2,8 @@ import classNames from "classnames";
 import React, { useState } from "react";
 import { data, sidebarData } from "../../database/data";
 import { SideNavbarElement } from "./SideNavbarElement";
+import { IconContext } from "react-icons";
+import { FaGithub } from "react-icons/fa";
 
 export const SideNavbar = () => {
   const [isSidebarActive, setIsSidebarActive] = useState(false);
@@ -68,6 +70,15 @@ export const SideNavbar = () => {
             );
           })}
         </div>
+          <ul className="inline-flex space-x-2">
+            <li>
+              <a title="Link to Github project" href="https://github.com/rupali-codes/LinksHub">
+                <IconContext.Provider value={{ className: "shared-class", size: "28" }}>
+                  <FaGithub/>
+                </IconContext.Provider>
+              </a>
+            </li>
+          </ul>
       </div>
     </div>
   );

--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -21,6 +21,15 @@ export const SideNavbar = () => {
           </span>
           <span className="text-violet-500">Hub</span>
         </h1>
+        <ul className="inline-flex space-x-2">
+            <li>
+              <a title="Link to Github project (External Link)" target="_blank" href="https://github.com/rupali-codes/LinksHub">
+                <IconContext.Provider value={{ className: "shared-class", size: "28" }}>
+                  <FaGithub/>
+                </IconContext.Provider>
+              </a>
+            </li>
+          </ul>
 
         <label className="btn btn-circle swap swap-rotate lg:hidden">
           <input
@@ -70,15 +79,6 @@ export const SideNavbar = () => {
             );
           })}
         </div>
-          <ul className="inline-flex space-x-2">
-            <li>
-              <a title="Link to Github project (External Link)" target="_blank" href="https://github.com/rupali-codes/LinksHub">
-                <IconContext.Provider value={{ className: "shared-class", size: "28" }}>
-                  <FaGithub/>
-                </IconContext.Provider>
-              </a>
-            </li>
-          </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
 #7

Created a hard-coded GitHub link and placed it with an icon below the sidebar navigation elements.
Please let me know if you would like this to be moved.

Is the plan to have a site config model where this data could be stored rather than hard coding the link ref?

![Linkhub](https://user-images.githubusercontent.com/20206340/211661324-db7768eb-1558-40bf-8382-287a60b4ed71.png)
