### PR TITLE
Fix: SearchBar position to top while scrolling

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -9,9 +9,11 @@ export const Searchbar = ({ setSearch }: SearchbarProps) => {
 
   return (
     <>
-      <label className="sr-only">Search</label>
+      <label htmlFor="simple-search" className="sr-only">
+        Search
+      </label>
       <div className="relative w-full">
-        <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center justify-center pointer-events-none">
           <svg
             aria-hidden="true"
             className="w-5 h-5 text-violet-500 dark:text-violet-500"
@@ -20,17 +22,16 @@ export const Searchbar = ({ setSearch }: SearchbarProps) => {
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
-              clip-rule="evenodd"
+              clipRule="evenodd"
             ></path>
           </svg>
         </div>
         <input
           type="text"
           id="simple-search"
-          className=" border bg-transparent border-gray-400 text-gray-900 text-sm rounded-lg block w-full pl-10 p-2.5  dark:border-gray-600  
-          dark:placeholder-gray-400 dark:text-gray-200 dark:focus:ring-violet-500 dark:focus:border-violet-500 focus:ring-violet-500 focus:border-violet-500 outline-none ease-in-out duration-300 "
+          className="block p-2.5 pl-10 w-full bg-transparent text-sm text-gray-900 dark:text-gray-200 border border-solid border-gray-400 dark:border-gray-600 focus:border-violet-500 dark:focus:border-violet-500 dark:focus:ring-violet-500 focus:ring-violet-500 dark:placeholder-gray-400 outline-none transition-all ease-in-out duration-300 rounded-lg"
           placeholder="Search"
           onChange={handleSearch}
           required

--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -72,15 +72,15 @@ export const SideNavbar = () => {
       <div
         ref={menuRef}
         className={classNames(
-          `lg:translate-x-0 lg:w-full w-[75%] p-4 bg-base-200 transition-all whitespace-nowrap ease-in duration-300 overflow-x-hidden h-screen z-[10] dark:bg-gray-900 dark:text-gray-300`,
+          `lg:translate-x-0 lg:w-full w-[75%] bg-base-200 transition-all whitespace-nowrap ease-in duration-300 overflow-x-hidden h-screen z-[10] dark:bg-gray-900 dark:text-gray-300`,
           sidebar ? "translate-x-[0%] " : "translate-x-[-100%]",
           theme === "light" ? "scrollColorLight" : "scrollColorDark"
         )}
       >
-        <div className="pb-4">
+        <div className="sticky top-0 left-0 right-0 p-4 w-full z-10 bg-base-200 dark:bg-gray-900 transiton-all duration-300 ease-in">
           <Searchbar setSearch={setSearch} />
         </div>
-        <div className="flex flex-col justify-center gap-8 pb-24">
+        <div className="flex flex-col justify-center px-4 gap-8 pb-24">
           {searchResults.map((item, index) => {
             return (
               <div key={index}>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #172

## Changes proposed

The search bar is now fixed at the top of the page while scrolling, providing a better user experience for searching content on the site. This update ensures the search bar is always accessible and visible to the user, improving the overall functionality of the search feature.

<!-- List all the proposed changes in your PR -->
## Screenshot or video

- Desktop result:

https://user-images.githubusercontent.com/94737463/218251939-16974ffe-524f-42a5-92a5-8896ee8c7777.mp4

- Mobile result

https://user-images.githubusercontent.com/94737463/218251957-38f57736-b907-4249-a0d0-03c0cd71b9c2.mp4

