### PR TITLE
Sort link cards

### DIFF
--- a/components/Cards/CardsList.tsx
+++ b/components/Cards/CardsList.tsx
@@ -16,6 +16,12 @@ const CardsList:FC<{ cards: IData[] }> = (props) => {
     setCurrentCard(null);
   }
 
+  cards.sort((a: IData, b: IData) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
   return (
     <>
       <ul className={`flex w-full w-full flex-wrap content-start gap-4 md:flex-row`}>


### PR DESCRIPTION
## Fixes Issue
Closes #393 
This PR fixes the **Sort Link cards issue**
 
## Changes proposed
```diff
+ cards.sort((a: IData, b: IData) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+ });
```
## Screenshots

#### Before

<img width="1254" alt="Screenshot 2023-04-05 at 12 07 02" src="https://user-images.githubusercontent.com/79666590/230168461-8c07d1ba-7f4d-4caf-89d3-627f99716caf.png">



#### After

<img width="1254" alt="Screenshot 2023-04-05 at 12 06 13" src="https://user-images.githubusercontent.com/79666590/230168580-2232b2a2-a657-4279-8080-129ed858801b.png">



## Note to reviewers

- [x] I've read the contributions [LinksHub Contribution Guidelines](https://github.com/rupali-codes/LinksHub/blob/4190b067f7f0ff4b2a39e6ec46dbce6d4c64b9fa/CONTRIBUTING.md)
- [x] My Pull Request has a descriptive title.
- [x] I'm open to Feedback.

#### Thank you for reviewing my code!