### PR TITLE
[Feature] Add default text when search is empty

### DIFF
--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -7,7 +7,6 @@ export const SideNavbarCategoryList: FC<{
   openByDefault: string
 }> = (props) => {
   const { items, openByDefault } = props
-  console.log('items', items)
   return (
     <ul className="mt-2 flex flex-col justify-center px-4 pb-24">
       {items.length !== 0 ? (

--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -21,7 +21,7 @@ export const SideNavbarCategoryList: FC<{
           )
         })
       ) : (
-        <div className="text-slate-500 py-2">No Links Found</div>
+        <div className="dark:text-gray-200 text-gray-500 text-lg text-center py-2">No Links Found</div>
       )}
     </ul>
   )

--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -1,17 +1,28 @@
-import { FC } from "react";
-import type { ISidebar } from "../../types";
-import { SideNavbarCategory } from "./SideNavbarCategory";
+import { FC } from 'react'
+import type { ISidebar } from '../../types'
+import { SideNavbarCategory } from './SideNavbarCategory'
 
-export const SideNavbarCategoryList: FC<{items: ISidebar[], openByDefault: string}> = (props) => {
-  const { items, openByDefault } = props;
-
+export const SideNavbarCategoryList: FC<{
+  items: ISidebar[]
+  openByDefault: string
+}> = (props) => {
+  const { items, openByDefault } = props
+  console.log('items', items)
   return (
     <ul className="mt-2 flex flex-col justify-center px-4 pb-24">
-      {items.map((item, index) => {
-        return (
-          <SideNavbarCategory key={index} item={item} openByDefault={openByDefault} />
-        );
-      })}
+      {items.length !== 0 ? (
+        items.map((item, index) => {
+          return (
+            <SideNavbarCategory
+              key={index}
+              item={item}
+              openByDefault={openByDefault}
+            />
+          )
+        })
+      ) : (
+        <div className="text-slate-500 py-2">No Links Found</div>
+      )}
     </ul>
-  );
-};
+  )
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Feature
- Add default text when search is empty

## Screenshots

<!-- Add all the screenshots which support your changes -->
![Screenshot 2023-04-26 at 12 08 19 PM](https://user-images.githubusercontent.com/108337259/234490267-935b8f07-6737-42b3-b54c-8ffe574fadd3.png)

## Note to reviewers

feature has been updated and tested its working perfect.
please verify the feature and let me know if there is any other modification required.
thank you