### PR TITLE
chore: [#485] Added Space Between Popup cons.

### DIFF
--- a/components/popup/index.tsx
+++ b/components/popup/index.tsx
@@ -32,9 +32,9 @@ const Popup: React.FC<{
                 <h2 className="max-w-[80%] text-2xl text-violet-500 capitalize">
                   {currentCard?.name}
                 </h2>
-                <CopyToClipboard url={currentCard?.url ?? ''} />
               </div>
-              <h5 className="max-w-[20%] text-xsm text-violet-500 capitalize flex items-center gap-1">
+              <h5 className="max-w-[25]%] text-xsm text-violet-500 capitalize flex items-center gap-2">
+                <CopyToClipboard url={currentCard?.url ?? ''} />
                 {currentCard?.language ? (
                   <>
                     <BsGlobe />

--- a/components/popup/index.tsx
+++ b/components/popup/index.tsx
@@ -33,7 +33,7 @@ const Popup: React.FC<{
                   {currentCard?.name}
                 </h2>
               </div>
-              <h5 className="max-w-[25]%] text-xsm text-violet-500 capitalize flex items-center gap-2">
+              <div className="max-w-[25]%] text-xsm text-violet-500 capitalize flex items-center gap-2">
                 <CopyToClipboard url={currentCard?.url ?? ''} />
                 {currentCard?.language ? (
                   <>
@@ -43,7 +43,7 @@ const Popup: React.FC<{
                 ) : (
                   ''
                 )}
-              </h5>
+              </div>
             </header>
             <p className="">{currentCard?.description}</p>
           </div>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #485 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
- Added extra space between the popup icons.
- I think the enclosing tag should be `div` instead of `h2`, so I made that change too.

<!-- List all the proposed changes in your PR -->

## Screenshots
<img width="502" alt="Screenshot 2023-04-26 at 7 12 49 PM" src="https://user-images.githubusercontent.com/87971509/234594509-0bcdd111-d985-4eab-a9b6-7009035cf905.png">

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
Could you please check the PR to see if it fixes the issue? Thank you for the opportunity!
<!-- Add notes to reviewers if applicable -->