### PR TITLE
feat(frontend): #513 toggle sidebar menu

### DIFF
--- a/components/SideNavbar/SideNavbarCategory.tsx
+++ b/components/SideNavbar/SideNavbarCategory.tsx
@@ -1,29 +1,23 @@
-import { FC, useEffect, useState } from "react";
+import { FC } from "react";
 import { FaAngleDown } from "react-icons/fa";
 import { SideNavbarElement } from "./SideNavbarElement";
-import type { ISidebar } from "../../types";
+import type { ISidebar,Category } from "../../types";
 
 export const SideNavbarCategory: FC<{
   item: ISidebar;
   openByDefault: string;
+  handleToggle: (category:Category, isOpen:boolean) => void;
+  isOpen: boolean;
 }> = (props) => {
-  const { item, openByDefault } = props;
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (openByDefault === item.category) {
-      setIsOpen(true);
-    }
-  }, [item.category, openByDefault]);
+  const { item, isOpen } = props;
 
   const handleToggle = () => {
-    setIsOpen((prevState) => !prevState);
+    props.handleToggle(item.category, isOpen);
   };
 
   let subcategoryList = null;
 
-  if (isOpen) {
+  if (props.isOpen) {
     subcategoryList = (
       <ul className="relative ml-1 border-l-2 border-slate-300 dark:border-slate-700 -pl-0.5">
         {item.subcategory

--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -1,5 +1,5 @@
-import { FC } from 'react'
-import type { ISidebar } from '../../types'
+import { FC, useState } from 'react'
+import type { ISidebar,Category } from '../../types'
 import { SideNavbarCategory } from './SideNavbarCategory'
 
 export const SideNavbarCategoryList: FC<{
@@ -7,6 +7,18 @@ export const SideNavbarCategoryList: FC<{
   openByDefault: string
 }> = (props) => {
   const { items, openByDefault } = props
+
+  const [isItemsOpen, setIsItemsOpen] = useState(items.map((item) => openByDefault === item.category))
+
+  /**
+   * @param category the category to toggle
+   * @param isOpen the current open state of the category
+   * @returns void
+   * @description toggle the open state of the category and closes all other categories
+   */
+  const handleToggle = (category:Category, isOpen:boolean) => {
+    setIsItemsOpen([...items].map(item=>item.category===category?!isOpen:isOpen))
+  }
   return (
     <ul className="mt-2 flex flex-col justify-center px-4 pb-24">
       {items.length !== 0 ? (
@@ -16,6 +28,8 @@ export const SideNavbarCategoryList: FC<{
               key={index}
               item={item}
               openByDefault={openByDefault}
+              handleToggle={handleToggle}
+              isOpen={isItemsOpen[index]}
             />
           )
         })

--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -17,7 +17,11 @@ export const SideNavbarCategoryList: FC<{
    * @description toggle the open state of the category and closes all other categories
    */
   const handleToggle = (category:Category, isOpen:boolean) => {
-    setIsItemsOpen([...items].map(item=>item.category===category?!isOpen:isOpen))
+    if(isOpen){
+      setIsItemsOpen([...items].map(()=>false))
+    } else {
+      setIsItemsOpen([...items].map(item=>item.category===category?!isOpen:isOpen))
+    }
   }
   return (
     <ul className="mt-2 flex flex-col justify-center px-4 pb-24">


### PR DESCRIPTION
## Fixes Issue
Closes #513 

## Changes proposed

- Now, the sidebar tabs behavior changed to "Only one tab open at a time".  
- Restructured the state management of open sidebar from individual component to the sidebarCategoryList component in order to close the other tabs.
- have handled the default open tab test case

## Screenshots

[Working screen capture](https://www.awesomescreenshot.com/video/17489435?key=b39540671563a23d53ea81a82afb36e2)

## Note to reviewers

I have restructured code in this way because I couldn't find any state management libs like redux. With redux, this could have been a bit easier and cleaner. But for now, according to me, this is the best approach without it. Still let me know if you have other ideas.