### PR TITLE
Adding direct links to dsa playlists

### DIFF
--- a/database/youtube/data-structures.json
+++ b/database/youtube/data-structures.json
@@ -1,65 +1,66 @@
-[{
+[
+  {
     "name": "Jennys Lectures CSIT",
     "description": "This channel provides free courses for DSA, C, C++, Python etc.",
-    "url": "https://www.youtube.com/@JennyslecturesCSIT",
+    "url": "https://www.youtube.com/watch?v=AT14lCXuMKI&list=PLdo5W4Nhv31bbKJzrsKfMpo_grxuLl8LU",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "english"
-},
-{
+  },
+  {
     "name": "CodeHelp - by Babbar",
     "description": "This channel provides free placement specific DSA course in C++.",
     "url": "https://www.youtube.com/playlist?list=PLDzeHZWIZsTryvtXdMr6rPh4IDexB5NIA",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "hindi"
-},
-{
+  },
+  {
     "name": "Apna College",
     "description": "This channel provides free courses for DSA, Java, C++, C etc.",
-    "url": "https://www.youtube.com/@ApnaCollegeOfficial",
+    "url": "https://www.youtube.com/watch?v=z9bZufPHFLU&list=PLfqMhTWNBTe0b2nM6JHVCnAkhQRGiZMSJ",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "hindi"
-},
-{
+  },
+  {
     "name": "CodeWithHarry",
-    "description": "A all in one destination for DSA, Python, C++, JavaScript, Nodejs, Java, PHP & many more.",
-    "url": "https://www.youtube.com/@CodeWithHarry/playlists",
+    "description": "Data Stucture and Algorithm playlist by codewith harry.",
+    "url": "https://www.youtube.com/watch?v=5_5oE5lgrhw&list=PLu0W_9lII9ahIappRPN0MCAgtOu3lQjQi",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "hindi"
-},
-{
+  },
+  {
     "name": "Luv",
     "description": "This channel provides free Competitive Programming content.",
-    "url": "https://www.youtube.com/@iamluv/playlists",
+    "url": "https://www.youtube.com/watch?v=OMcxQ3IY-qc&list=PLauivoElc3ggagradg8MfOZreCMmXMmJ-",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "hindi"
-},
-{
+  },
+  {
     "name": "take U forward",
     "description": "One of the best channel for DSA, you will find the thought process behind every problem and not just simple algorithms.",
-    "url": "https://www.youtube.com/@takeUforward/featured",
+    "url": "https://www.youtube.com/watch?v=EAR7De6Goz4&list=PLgUwDviBIf0oF6QL8m22w1hIDC1vJ_BHz",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "english"
-},
-{
+  },
+  {
     "name": "Pepcoding",
     "description": "One of the best channel for DSA in Java and helpful for both students and working professionals.",
-    "url": "https://www.youtube.com/@Pepcoding/featured",
+    "url": "https://www.youtube.com/watch?v=F8xQ5joLlD0&list=PL-Jc9J83PIiFj7YSPl2ulcpwy-mwj1SSk",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "hindi"
-},
-{
+  },
+  {
     "name": "Abdul Bari",
     "description": "This channel is focused on teaching Data Structures and Algorithms. They also provide courses on different computer science subjects.",
-    "url": "https://www.youtube.com/@abdul_bari",
+    "url": "https://www.youtube.com/watch?v=0IAPZzGSbME&list=PLAXnLdrLnQpRcveZTtD644gM9uzYqJCwr",
     "category": "youtube",
     "subcategory": "dsa",
     "language": "english"
-}
+  }
 ]


### PR DESCRIPTION
## Issue
Fixes #565 
## Changes proposed

Adding direct links of  data strucure and algorithm playlist instead of their channel links. 
@CBID2 
## Screenshots

<!-- Add all the screenshots which support your changes -->

![image](https://github.com/rupali-codes/LinksHub/assets/81584747/fa35faaa-de7d-41ef-9095-4809c5887381)
