### PR TITLE
Feat: add skiplink

### DIFF
--- a/components/SkipLink/SkipLink.tsx
+++ b/components/SkipLink/SkipLink.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react'
+
+export const SkipLink: FC = () => (
+  <div className="z-40 flex absolute left-1/2 transform -translate-x-1/2">
+    <a
+      href="#main"
+      className="-translate-y-20   focus:transform-none mt-2 flex items-center justify-center gap-2 rounded-2xl border border-dashed border-transparent bg-violet-600 px-6 py-2 text-center text-white"
+    >
+      Skip to main content
+    </a>
+  </div>
+)

--- a/layouts/GeneralLayout.tsx
+++ b/layouts/GeneralLayout.tsx
@@ -3,22 +3,26 @@ import { Footer } from "components/Footer/Footer";
 import { SideNavbar } from "components/SideNavbar";
 import { Header } from "components/Header/Header";
 import { Aside } from "components/Aside/Aside";
+import { SkipLink } from 'components/SkipLink/SkipLink'
 
 const GeneralLayout = ({ children }: { children: ReactNode }) => {
-  
   return (
     <>
+      <SkipLink />
       <Header />
       <SideNavbar />
       <div className="row-start-2 row-end-3 min-h-[100vh-72px] w-full bg-gray-100 dark:bg-[#101623]">
         <Aside />
-        <main className="h-full px-4 lg:ml-[290px] lg:w-[calc(100%-290px)]">
+        <main
+          className="h-full px-4 lg:ml-[290px] lg:w-[calc(100%-290px)]"
+          id="main"
+        >
           {children}
           <Footer />
         </main>
       </div>
     </>
-  );
-};
+  )
+}
 
 export default GeneralLayout;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #498 

Closes #498 

## Changes proposed

Add a skip link component to the beginning of the layout, which is normally hidden but is the first thing in the tab order and becomes visible when a keyboard user focuses on it. Activating the link jumps to the main content and allows the user to skip over tabbing through all of the navigation links.

## Screenshots

My computer is misbehaving and won't let me take a screenshot right now. But to see the link just navigate to the site and start tabbing. It will appear as the first thing in the tab order in the top center of the page.

## Note to reviewers

<!-- Add notes to reviewers if applicable -->