### PR TITLE
[fix] add a special note for GSSoC'23 contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ The subcategory object should follow this pattern
 * If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark. 
 * **Note:** If you are apart of GSSoC'23, please check the *I am a GSSoC'23 contributor* check mark as shown in the image below:  
 ![issue checkmark for gssoc'23](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/c31b245d-420a-4513-bb58-d6be8b2fcdb1)
- **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
+ * **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
  
 * If you aren't the owner of the issue, please comment that you're willing to work on the issue and wait for maintainers to assign you the issue. Also, don't work on the issue if you're NOT assigned.
 * Please do **not** start working on the issue if you aren't yet assigned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,12 @@ The subcategory object should follow this pattern
 --- 
 ## Issues
 * Select an issue template from [issues](https://github.com/rupali-codes/LinksHub/issues/new/choose) tab. Otherwise, choose **Other** if it doesn't match what you're looking for.
-* When creating an issue, make sure you fill up all the fields properly.
+* When creating an issue, make sure you fill up all the fields properly. 
 * Make sure that you are NOT raising a **duplicate issue**.
-* If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark.
+* If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark. 
+* **Note:** If you are apart of GSSoC'23, please check the *I am a GSSoC'23 contributor* check mark as shown in the image below:  
+![GSSOC check mark](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/e289b12a-ea59-47b4-b48b-4038343286d4).
+ 
 * If you aren't the owner of the issue, please comment that you're willing to work on the issue and wait for maintainers to assign you the issue. Also, don't work on the issue if you're NOT assigned.
 * Please do **not** start working on the issue if you aren't yet assigned.
 * Wwork on only ONE issue at a time. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ The subcategory object should follow this pattern
 * Make sure that you are NOT raising a **duplicate issue**.
 * If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark. 
 * **Note:** If you are apart of GSSoC'23, please check the *I am a GSSoC'23 contributor* check mark as shown in the image below:  
-![GSSOC check mark](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/e289b12a-ea59-47b4-b48b-4038343286d4).
+![GSSOC check mark](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/e289b12a-ea59-47b4-b48b-4038343286d4). **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
  
 * If you aren't the owner of the issue, please comment that you're willing to work on the issue and wait for maintainers to assign you the issue. Also, don't work on the issue if you're NOT assigned.
 * Please do **not** start working on the issue if you aren't yet assigned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ The subcategory object should follow this pattern
 * If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark. 
 * **Note:** If you are apart of GSSoC'23, please check the *I am a GSSoC'23 contributor* check mark as shown in the image below:  
 ![issue checkmark for gssoc'23](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/c31b245d-420a-4513-bb58-d6be8b2fcdb1)
- * **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
+ * **Do not create the PR until you have confirmed with the maintainers that you are participating in this program** 
  
 * If you aren't the owner of the issue, please comment that you're willing to work on the issue and wait for maintainers to assign you the issue. Also, don't work on the issue if you're NOT assigned.
 * Please do **not** start working on the issue if you aren't yet assigned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,12 @@ The subcategory object should follow this pattern
 * Make sure that you are NOT raising a **duplicate issue**.
 * If you want to work on the issue, please click on the *I am willing to work on this issue* checkmark. 
 * **Note:** If you are apart of GSSoC'23, please check the *I am a GSSoC'23 contributor* check mark as shown in the image below:  
-![GSSOC check mark](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/e289b12a-ea59-47b4-b48b-4038343286d4). **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
+![issue checkmark for gssoc'23](https://github.com/CBID2/LinksHub-my-version-/assets/105683440/c31b245d-420a-4513-bb58-d6be8b2fcdb1)
+ **Do not create the PR unitl you have confirmed with the maintainers that you are participating in this program** 
  
 * If you aren't the owner of the issue, please comment that you're willing to work on the issue and wait for maintainers to assign you the issue. Also, don't work on the issue if you're NOT assigned.
 * Please do **not** start working on the issue if you aren't yet assigned.
-* Wwork on only ONE issue at a time. 
+* Work on only **ONE** issue at a time. 
   
 **Closing the issue**
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #590 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
I added a special note for GSSoC'23 contributors in the Issues section. 
## Screenshots

<!-- Add all the screenshots which support your changes -->

![proof for issue](https://github.com/rupali-codes/LinksHub/assets/105683440/d4a64417-ed10-4006-94bf-a9232158a8e4)

## Note to reviewers
Hey, @rupali-codes! :) I decided to create this special note to make it easier for us to determine if contributors are participating in GSSoC'23. Let me know what you think. :)  
<!-- Add notes to reviewers if applicable -->