### PR TITLE
Added github action for closing old issues

### DIFF
--- a/.github/workflows/close_old_issues.yaml
+++ b/.github/workflows/close_old_issues.yaml
@@ -1,0 +1,34 @@
+name: Close Old Issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Close Old Issues
+        run: |
+          open_issues=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open" \
+            | jq -r '.[] | .number')
+
+          for issue in $open_issues; do
+            # Get the last updated timestamp of the issue
+            last_updated=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$issue" \
+              | jq -r '.updated_at')
+
+            days_since_update=$(( ( $(date +%s) - $(date -d "$last_updated" +%s) ) / 86400 ))
+
+            if [ $days_since_update -gt 45 ]; then
+              curl -s -X PATCH -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -d '{"state":"closed"}' \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$issue"
+            fi
+          done


### PR DESCRIPTION
## Fixes #688

## Changes proposed

I have created a workflow for closing old issues. Please note that this action uses the personal access token for authorization so a `GITHUB_TOKEN` has to be added to the repository's secret 