### PR TITLE
Update close_old_prs.yaml

### DIFF
--- a/.github/workflows/close_old_prs.yaml
+++ b/.github/workflows/close_old_prs.yaml
@@ -30,5 +30,11 @@ jobs:
 
               if (!linkedIssue) {
                 await github.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+                await github.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: "This pull request has been closed because it does not mention the issue that it solves. Please refer to the [Contributing files](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md#issues) to help you add this information. Then, tag the maintainers so your PR can be reopened."
+                });
               }
             });

--- a/.github/workflows/close_old_prs.yaml
+++ b/.github/workflows/close_old_prs.yaml
@@ -1,14 +1,14 @@
-name: Close Old PRs
+name: Close PRs Without Linked Issues
 on:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
-  close_old_prs:
+  close_prs_without_issue:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check and Close Old PRs
+      - name: Check and Close PRs Without Linked Issues
         id: close_prs
         uses: actions/github-script@v6
         env:
@@ -16,24 +16,19 @@ jobs:
         with:
           script: |
             const daysThreshold = 45;
-            const octokit = require('@octokit/rest')();
-
-            octokit.authenticate({
-              type: 'token',
-              token: process.env.GITHUB_TOKEN,
-            });
 
             const { owner, repo } = context.repo;
 
-            const { data: pullRequests } = await octokit.pulls.list({ owner, repo, state: 'open' });
+            const { data: pullRequests } = await github.pulls.list({ owner, repo, state: 'open' });
 
             pullRequests.forEach(async (pr) => {
-              const { data: reviews } = await octokit.pulls.listReviews({ owner, repo, pull_number: pr.number });
+              const { data: issues } = await github.issues.listForRepo({ owner, repo, per_page: 100 });
 
-              const lastReview = reviews[reviews.length - 1];
-              const daysSinceLastUpdate = Math.floor((new Date() - new Date(lastReview.submitted_at)) / (1000 * 60 * 60 * 24));
+              const linkedIssue = issues.find((issue) =>
+                issue.pull_request && issue.pull_request.url === pr.url
+              );
 
-              if (daysSinceLastUpdate >= daysThreshold) {
-                await octokit.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+              if (!linkedIssue) {
+                await github.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
               }
             });


### PR DESCRIPTION
## Fixes Issue
Closes #722 
Closes #715  


## Changes proposed

- To fix this issue, I modified the code and used the `octokit instance` provided by the `'actions/github-script'` action directly.

- This `octokit instance` is accessed using the provided `github object`. The code now checks if each pull request has a linked issue by searching for an issue with a matching pull_request URL. If no linked issue is found, the pull request is closed.

## Screenshots
![image](https://github.com/rupali-codes/LinksHub/assets/115401171/d970daa7-750f-460e-a372-3f6311a72f8b)

<br>

#### I noticed that it closes two relative issues out of which one issue i.e `Issue 722` is assigned to me and remaining one i.e `Issue 715` is not, as a result PR is not showing me as assignee, I hope that don't discard my gssoc entry :)
- Also please add required label for this PR

![image](https://github.com/rupali-codes/LinksHub/assets/115401171/9e800ae6-4535-433c-ab62-f26e7d508d9e)



*Any kind of feedback is appreciated and let me know if this works or not