### PR TITLE
chore: Added one link for ui generation

### DIFF
--- a/database/frontend/ui-generators.json
+++ b/database/frontend/ui-generators.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "Fffuel.co",
+    "description": "fffuel is a collection of color tools and free SVG generators for gradients, patterns, textures, shapes & backgrounds.",
+    "url": "https://fffuel.co/",
+    "category": "frontend",
+    "subcategory": "ui-generators"
+  },
+  {
     "name": "Neumorphism.io",
     "description": "It's a platform where you can generate Soft-UI CSS elements for your webiste or app.",
     "url": "https://neumorphism.io/#e0e0e0",


### PR DESCRIPTION
chore: Add one link(https://fffuel.co/) for UI generation. fffuel is a collection of color tools and free SVG generators for gradients, patterns, textures, shapes & backgrounds.

Closes #758

<img width="1440" alt="image" src="https://github.com/rupali-codes/LinksHub/assets/55452218/e7f4c131-fb6f-4e6a-9ecd-2c19e7f6e0be">
