### PR TITLE
Frontend sub-cats closed on default

### DIFF
--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -23,7 +23,7 @@ export const SideNavbarBody: FC<{}> = () => {
       <SideNavbarCategoryList
         items={searchResults}
         isSearching={debouncedSearch.length > 0}
-        openByDefault={'frontend'}
+        openByDefault={''}
       />
     </div>
   )


### PR DESCRIPTION
Closes #788.

## Changes proposed
The frontend sub-categories appear on their own even if the user hasn't clicked them. I had proposed for the frontend sub categories to remain closed on default.

## Screenshots
<!-- Add all the screenshots which support your changes -->
![s](https://github.com/rupali-codes/LinksHub/assets/102184647/f05cb36f-e716-4661-93b9-c340329d8522)
I have made the required change which helps the frontend to be closed on default.

## Note to reviewers

<!-- Add notes to reviewers if applicable -->