### PR TITLE
💡 [Feat]: Add aria-label for Social anchors & Some minor changes

### DIFF
--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -36,7 +36,7 @@ const Card: FC<{ data: IData }> = (props) => {
             onClick={(e) => e.stopPropagation()}
             href={url}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className={
               'mt-2 flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-transparent bg-violet-600 px-6 py-2 text-center text-white duration-100 hover:border-violet-400 hover:bg-transparent hover:text-violet-500 dark:hover:text-violet-400'
             }

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -7,13 +7,18 @@ export const Footer: FC = () => {
       <p className="leading-7 tracking-wide text-center text-black dark:text-violet-400">
         <span>&copy; {new Date().getFullYear()} LinksHub | </span>
         Developed by{' '}
-        <Link href="https://linkfree.io/rupali-codes" target="_blank">
+        <Link 
+          href="https://linkfree.io/rupali-codes" 
+          target="_blank" 
+          rel="noopener noreferrer"
+        >
           <span className="dark:text-gray-200 underline">Rupali Haldiya</span>
         </Link>{' '}
         and{' '}
         <Link
           href="https://github.com/rupali-codes/LinksHub/graphs/contributors"
           target="_blank"
+          rel="noopener noreferrer"
         >
           <span className="dark:text-gray-200 underline">
            Open Source Community

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -14,6 +14,7 @@ export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
         target="_blank"
         rel="noopener noreferrer"
         href="https://discord.com/invite/NvK67YnJX5"
+        aria-label="Visit us on Discord"
         >
           <IconContext.Provider
             value={{ className: "shared-class", size: "24" }}
@@ -29,6 +30,7 @@ export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
         target="_blank"
         rel="noopener noreferrer"
         href="https://github.com/rupali-codes/LinksHub"
+        aria-label="Visit us on Github"
         >
           <IconContext.Provider
             value={{ className: "shared-class", size: "24" }}
@@ -44,6 +46,7 @@ export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
           target="_blank"
           rel="noopener noreferrer"
           href="https://twitter.com/the_linkshub"
+          aria-label="Visit us on Twitter"
         >
         <IconContext.Provider
           value={{ className: "shared-class", size: "24" }}


### PR DESCRIPTION
## Fixes Issue
- Closes: #842 

## Changes proposed
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people