### PR TITLE
fix: overflowing content bug

### DIFF
--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -17,7 +17,7 @@ const Card: FC<{ data: IData }> = (props) => {
       <div className="card-body">
         <header className="flex justify-between items-center">
           <h2
-            className="cursor-default truncate ... text-xl text-violet-600 dark:text-violet-400"
+            className="cursor-default text-xl text-violet-600 dark:text-violet-400"
             title={name}
           >
             {name}

--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -17,7 +17,7 @@ const Card: FC<{ data: IData }> = (props) => {
       <div className="card-body">
         <header className="flex justify-between items-center">
           <h2
-            className="cursor-default text-xl text-violet-600 dark:text-violet-400"
+            className="cursor-default md:truncate ... text-xl text-violet-600 dark:text-violet-400"
             title={name}
           >
             {name}


### PR DESCRIPTION
## Fixes Issue

Closes #732 

## Changes proposed

- I have fixed the responsive bug.

## Screenshots

|  Before | Updated |
|:--------:|:----------:|
| ![before](https://user-images.githubusercontent.com/74038190/240995120-29613209-4953-4f5e-b49c-37aa29154767.png) | ![after](https://github.com/rupali-codes/LinksHub/assets/74038190/9e67444a-b9b2-4616-9a2d-8a6172fee73b) |


## Note to reviewers

- I have properly tested, and I believe this is the sole reason for the bug.
- I have checked; other contents are not impacted.
- I have verified this by increasing the header text and adding other custom values.

