### PR TITLE
feat: add github fork button

### DIFF
--- a/components/ForkButton/GitHubForkButton.tsx
+++ b/components/ForkButton/GitHubForkButton.tsx
@@ -1,0 +1,47 @@
+import { FC } from "react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { FaCodeBranch } from "react-icons/fa";
+import { useTheme } from "next-themes";
+
+export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
+    const { resolvedTheme } = useTheme();
+    const [forkCount, setForkCount] = useState(0);
+
+    useEffect(() => {
+        const fetchForkCount = async () => {
+            try {
+                const response = await fetch(`https://api.github.com/repos/${repo}`);
+                const data = await response.json();
+                setForkCount(data.forks);
+            } catch (error) {
+                console.error("Error fetching fork count:", error);
+            }
+        };
+
+        fetchForkCount();
+    }, [repo]);
+
+    const isDarkMode = resolvedTheme === "dark";
+
+    const buttonStyles = `inline-flex items-center px-4 py-1 text-sm font-semibold ${isDarkMode ? "bg-white text-black" : "bg-transparent text-violet-500 border border-violet-500"
+        } border-transparent rounded-sm transition-colors shadow-md`;
+    // Other Styles for Light Mode: [bg-violet-500 text-white] OR [text-black-500 border border-black]
+
+    return (
+        <Link
+            href={`https://github.com/${repo}`}
+            passHref
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Fork ${repo} on GitHub`}
+        >
+            <div className={buttonStyles}>
+                <FaCodeBranch className="mr-1" />
+                <span className="font-semibold">Fork</span>
+                <span className="ml-2">{forkCount}</span>
+            </div>
+
+        </Link>
+    );
+};

--- a/components/ForkButton/GitHubForkButton.tsx
+++ b/components/ForkButton/GitHubForkButton.tsx
@@ -24,7 +24,7 @@ export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
 
     return (
         <Link
-            href={`https://github.com/${repo}`}
+            href={`https://github.com/${repo}/fork`}
             passHref
             target="_blank"
             rel="noopener noreferrer"

--- a/components/ForkButton/GitHubForkButton.tsx
+++ b/components/ForkButton/GitHubForkButton.tsx
@@ -2,10 +2,8 @@ import { FC } from "react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { FaCodeBranch } from "react-icons/fa";
-import { useTheme } from "next-themes";
 
 export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
-    const { resolvedTheme } = useTheme();
     const [forkCount, setForkCount] = useState(0);
 
     useEffect(() => {
@@ -22,10 +20,6 @@ export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
         fetchForkCount();
     }, [repo]);
 
-    const isDarkMode = resolvedTheme === "dark";
-
-    const buttonStyles = `inline-flex items-center px-4 py-1 text-sm font-semibold ${isDarkMode ? "bg-white text-black" : "bg-transparent text-violet-500 border border-violet-500"
-        } border-transparent rounded-sm transition-colors shadow-md`;
     // Other Styles for Light Mode: [bg-violet-500 text-white] OR [text-black-500 border border-black]
 
     return (
@@ -36,7 +30,7 @@ export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
             rel="noopener noreferrer"
             aria-label={`Fork ${repo} on GitHub`}
         >
-            <div className={buttonStyles}>
+            <div className="inline-flex items-center px-4 py-1 text-sm font-semibold bg-transparent text-violet-500 border border-violet-500 border-transparent rounded-sm transition-colors shadow-md">
                 <FaCodeBranch className="mr-1" />
                 <span className="font-semibold">Fork</span>
                 <span className="ml-2">{forkCount}</span>

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -1,35 +1,15 @@
 import { FC } from "react";
 import { IconContext } from "react-icons";
 import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa";
-import Link from "next/link";
-import { useEffect } from "react";
+import { GitHubForkButton } from "components/ForkButton/GitHubForkButton";
 
 export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
   const { className } = props;
 
-  useEffect(() => {
-    const script = document.createElement('script')
-    script.src = 'https://buttons.github.io/buttons.js'
-    script.async = true
-    script.defer = true
-    document.head.appendChild(script)
-    return () => {
-      document.head.removeChild(script)
-    }
-  }, [])
   return (
     <ul className={`flex items-center gap-6 ${className}`}>
-      <li className="mt-2 mr-2 hidden md:block">
-        <Link
-          className="github-button"
-          href="https://github.com/rupali-codes/LinksHub"
-          data-icon="octicon-repo-forked"
-          data-size="large"
-          data-show-count="true"
-          aria-label="Fork rupali-codes/LinksHub on GitHub"
-        >
-          Fork
-        </Link>
+      <li className="mr-2 hidden md:block">
+        <GitHubForkButton repo="rupali-codes/LinksHub" />
       </li>
       <li>
         <a

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -9,7 +9,7 @@ export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
   return (
     <ul className={`flex items-center gap-6 ${className}`}>
       <li className="mr-2 hidden md:block">
-        <GitHubForkButton repo="rupali-codes/LinksHub/fork" />
+        <GitHubForkButton repo="rupali-codes/LinksHub" />
       </li>
       <li>
         <a

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -9,7 +9,7 @@ export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
   return (
     <ul className={`flex items-center gap-6 ${className}`}>
       <li className="mr-2 hidden md:block">
-        <GitHubForkButton repo="rupali-codes/LinksHub" />
+        <GitHubForkButton repo="rupali-codes/LinksHub/fork" />
       </li>
       <li>
         <a

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -1,20 +1,44 @@
 import { FC } from "react";
 import { IconContext } from "react-icons";
-import {FaDiscord, FaGithub, FaTwitter} from "react-icons/fa";
+import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa";
+import Link from "next/link";
+import { useEffect } from "react";
 
-export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
+export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
   const { className } = props;
 
+  useEffect(() => {
+    const script = document.createElement('script')
+    script.src = 'https://buttons.github.io/buttons.js'
+    script.async = true
+    script.defer = true
+    document.head.appendChild(script)
+    return () => {
+      document.head.removeChild(script)
+    }
+  }, [])
   return (
     <ul className={`flex items-center gap-6 ${className}`}>
+      <li className="mt-2 mr-2 hidden md:block">
+        <Link
+          className="github-button"
+          href="https://github.com/rupali-codes/LinksHub"
+          data-icon="octicon-repo-forked"
+          data-size="large"
+          data-show-count="true"
+          aria-label="Fork rupali-codes/LinksHub on GitHub"
+        >
+          Fork
+        </Link>
+      </li>
       <li>
         <a
-        title="Link to Discord server (External Link)"
-        className="dark:text-gray-300"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://discord.com/invite/NvK67YnJX5"
-        aria-label="Visit us on Discord"
+          title="Link to Discord server (External Link)"
+          className="dark:text-gray-300"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://discord.com/invite/NvK67YnJX5"
+          aria-label="Visit us on Discord"
         >
           <IconContext.Provider
             value={{ className: "shared-class", size: "24" }}
@@ -25,17 +49,17 @@ export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
       </li>
       <li>
         <a
-        title="Link to Github project (External Link)"
-        className="dark:text-gray-300"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://github.com/rupali-codes/LinksHub"
-        aria-label="Visit us on Github"
+          title="Link to Github project (External Link)"
+          className="dark:text-gray-300"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/rupali-codes/LinksHub"
+          aria-label="Visit us on Github"
         >
           <IconContext.Provider
             value={{ className: "shared-class", size: "24" }}
           >
-              <FaGithub className="hover:text-violet-500 transition duration-300 ease-in-out" />
+            <FaGithub className="hover:text-violet-500 transition duration-300 ease-in-out" />
           </IconContext.Provider>
         </a>
       </li>
@@ -48,11 +72,11 @@ export const SocialMediaIconsList:FC<{className?: string}> = (props) => {
           href="https://twitter.com/linkshubdotdev"
           aria-label="Visit us on Twitter"
         >
-        <IconContext.Provider
-          value={{ className: "shared-class", size: "24" }}
-        >
-          <FaTwitter className="hover:text-violet-500 transition duration-300 ease-in-out" />
-        </IconContext.Provider>
+          <IconContext.Provider
+            value={{ className: "shared-class", size: "24" }}
+          >
+            <FaTwitter className="hover:text-violet-500 transition duration-300 ease-in-out" />
+          </IconContext.Provider>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Fixes Issue

Closes #774 

## Changes proposed

- Add the button using https://github.com/buttons/github-buttons as discussed in the issue

## Screenshots

> Dark Mode Lg
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/00b85764-ad2a-4130-b2a5-34eedbe8adf7)

> Light Mode Lg
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/02ca74ab-7c7c-45ea-8bd4-4f7c5a117f42)

It doesn't support custom `CSS` code, and I tried applying it to the parent container, as that is the only way it works. So, this is the best we can do.

> Dark Mode Sm
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/3a4d7121-5bde-41df-b2fd-ba744693dbb8)

I believe it is unnecessary to display the fork button on small-screen devices as it may not place well with the social media icons.

## Note to reviewers

As I mentioned earlier, please ensure that the same is done for maintaining a clean history.
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/c67e5e12-4d91-43c2-a3cc-650f349c464c)
