### PR TITLE
docs: add workflow to lock issue conversations

### DIFF
--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -19,4 +19,4 @@ jobs:
           exclude-issue-labels: '🚀 ready'
           skip-closed-issue-comment: true
           issue-comment: >
-            To reduce notifications, issues are locked. Your issue will be unlocked when we will add label as `🚀 ready`.
+            To reduce notifications, issues are locked. Your issue will be unlocked when we add the label, `🚀 ready`.

--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -1,0 +1,22 @@
+name: 'Issue Lockdown'
+
+on:
+  issues:
+    types: opened
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v3 # Reference: https://github.com/dessant/repo-lockdown
+        with:
+          close-issue: false
+          process-only: 'issues'
+          issue-labels: '🔒 locked'
+          exclude-issue-labels: '🚀 ready'
+          skip-closed-issue-comment: true
+          issue-comment: >
+            To reduce notifications, issues are locked. Your issue will be unlocked when we will add label as `🚀 ready`.


### PR DESCRIPTION
## Fixes Issue

Resolved #966 

## Changes proposed

- Reference: https://github.com/dessant/repo-lockdown

## Code

```yml
name: 'Issue Lockdown'

on:
  issues:
    types: opened

permissions:
  issues: write

jobs:
  action:
    runs-on: ubuntu-latest
    steps:
      - uses: dessant/repo-lockdown@v3 # Reference: https://github.com/dessant/repo-lockdown
        with:
          close-issue: false
          process-only: 'issues'
          issue-labels: '🔒 locked'
          exclude-issue-labels: '🚀 ready'
          skip-closed-issue-comment: true
          issue-comment: >
            To reduce notifications, issues are locked. Your issue will be unlocked when we will add label as `🚀 ready`.
```

## Note to reviewers

- The bot will add the `🔒 locked` label before locking the conversation, and you can unlock the conversation by adding the `🚀 ready` label.
- If you prefer a different label, please let me know, and I will update it accordingly.

@rupali-codes 
Please review the workflow.