### PR TITLE
Fix issue #1042 Categories not showing when the search is empty

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -11,7 +11,10 @@ export const Searchbar: React.FC<SearchbarProps> = ({ setSearch }) => {
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value)
-    setErrorMessage('')
+    if (e.target.value.trim() === '') {
+      setErrorMessage('')
+      setSearch(searchQuery)
+    }
   }
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -13,7 +13,7 @@ export const Searchbar: React.FC<SearchbarProps> = ({ setSearch }) => {
     setSearchQuery(e.target.value)
     if (e.target.value.trim() === '') {
       setErrorMessage('')
-      setSearch(searchQuery)
+      setSearch('')
     }
   }
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
This PR closes issue #1042

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
I made changes in Searchbar Components 
when the input is empty search string will also be empty 

## Screenshots

<!-- Add all the screenshots which support your changes -->


https://github.com/rupali-codes/LinksHub/assets/65841021/4062c704-1738-4b9b-b19c-543968926509


## Note to reviewers
So there is one new issue that when the searched categories are open and if we go back to menu the starting categories are open
<!-- Add notes to reviewers if applicable -->