### PR TITLE
 Next.js Documentation are Added Under Official Docs

### DIFF
--- a/database/resources/official-docs.json
+++ b/database/resources/official-docs.json
@@ -28,13 +28,13 @@
     "subcategory": "officialdocs"
   },
   {
-
    "name": "Next.js",
    "description": "This page provides an overview of the Next.js documentation and related resources.",
    "url": "https://nextjs.org/",
    "category": "resources",
    "subcategory": "officialdocs"
   },
+  {
     "name": "Angular",
     "description": "This page is an overview of the Angular documentation and related resources.",
     "url": "https://angular.io/docs",

--- a/database/resources/official-docs.json
+++ b/database/resources/official-docs.json
@@ -26,5 +26,12 @@
     "url": "https://docs.djangoproject.com/en/4.2/",
     "category": "resources",
     "subcategory": "officialdocs"
+  },
+  {
+   "name": "Next.js",
+   "description": "This page provides an overview of the Next.js documentation and related resources.",
+   "url": "https://nextjs.org/",
+   "category": "resources",
+   "subcategory": "officialdocs"
   }
 ]

--- a/database/resources/official-docs.json
+++ b/database/resources/official-docs.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "Next.js",
-    "description": "Explore the Next.js documentation and related resources",
+    "description": "This documentation is a comprehensive resource for building fast, scalable, and production-ready web apps using Next.js",
     "url": "https://nextjs.org/",
     "category": "resources",
     "subcategory": "officialdocs"

--- a/database/resources/official-docs.json
+++ b/database/resources/official-docs.json
@@ -20,19 +20,19 @@
     "category": "resources",
     "subcategory": "officialdocs"
   },
-   {
-   "name": "Django",
+  {
+    "name": "Django",
     "description": "This page gives an overview of the Django documentation and related resources.",
     "url": "https://docs.djangoproject.com/en/4.2/",
     "category": "resources",
     "subcategory": "officialdocs"
   },
   {
-   "name": "Next.js",
-   "description": "This page provides an overview of the Next.js documentation and related resources.",
-   "url": "https://nextjs.org/",
-   "category": "resources",
-   "subcategory": "officialdocs"
+    "name": "Next.js",
+    "description": "Explore the Next.js documentation and related resources",
+    "url": "https://nextjs.org/",
+    "category": "resources",
+    "subcategory": "officialdocs"
   },
   {
     "name": "Angular",
@@ -40,6 +40,5 @@
     "url": "https://angular.io/docs",
     "category": "resources",
     "subcategory": "officialdocs"
-
   }
 ]


### PR DESCRIPTION
 Next.js Documentation are Added in Official Docs in Resources

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes  #1141
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
Offical Documentation for Django is added under Offical Docs Section
## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->