### PR TITLE
add the new link for OneCompiler

### DIFF
--- a/database/frontend/online-code-editors.json
+++ b/database/frontend/online-code-editors.json
@@ -71,7 +71,7 @@
   },
   {
     "name": "OneCompiler",
-    "description": "Got a new feature for your web app! implement it on mobile, anywhere. It supports over 40 programming languages and frontend frameworks.",
+    "description": "Got a new feature for your web app? Implement it with OneCompiler on mobile and anywhere. It supports over 60+ programming languages and frontend frameworks.",
     "url": "https://onecompiler.com/",
     "category": "frontend",
     "subcategory": "online-code-editors"

--- a/database/frontend/online-code-editors.json
+++ b/database/frontend/online-code-editors.json
@@ -70,6 +70,13 @@
     "subcategory": "online-code-editors"
   },
   {
+    "name": "OneCompiler",
+    "description": "Got a new feature for your web app! implement it on mobile, anywhere. It supports over 40 programming languages and frontend frameworks.",
+    "url": "https://onecompiler.com/",
+    "category": "frontend",
+    "subcategory": "online-code-editors"
+  },
+  {
     "name": "StackBlitz",
     "description": "StackBlitz is an online code editor powered by WebContainers that allows users to create, collaborate, and deploy web applications.",
     "url": "https://stackblitz.com/",


### PR DESCRIPTION
Closes #1118

## Fixes Issue
Closes #1118 

## Changes proposed
Add a new online code editor for html, js, css with compiler for 60+ programming languages and frontend frameworks.
## Screenshots
<img width="1440" alt="Screenshot 2023-06-26 at 20 10 40" src="https://github.com/rupali-codes/LinksHub/assets/89871918/02773226-a609-4910-9156-64ef7e3a3fef">


## Note to reviewers
Should I commit changes after running it locally?