### PR TITLE
Add nuxt Documentation to Official Docs in Resources 📃

### DIFF
--- a/database/resources/official-docs.json
+++ b/database/resources/official-docs.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "Next.js",
-    "description": "This documentation is a comprehensive resource for building fast, scalable, and production-ready web apps using Next.js",
+    "description": "This documentation is a comprehensive resource for building fast, scalable, and production-ready web apps using Next.js.",
     "url": "https://nextjs.org/",
     "category": "resources",
     "subcategory": "officialdocs"
@@ -45,6 +45,13 @@
     "name": "Vue.js",
     "description": "This page contains comprehensive documentation of Vue.js, a progressive JavaScript framework.",
     "url": "https://vuejs.org/",
+    "category": "resources",
+    "subcategory": "officialdocs"
+  },
+  {
+    "name": "Nuxt.js",
+    "description": "Nuxt.js is a progressive framework based on Vue.js that simplifies the development of server-side rendered (SSR) and static generated (SSG) Vue.js applications.",
+    "url": "https://nuxtjs.org/",
     "category": "resources",
     "subcategory": "officialdocs"
   }


### PR DESCRIPTION
## Fixes Issue
Closes #1203

## Changes Proposed

###  **I have added the nuxt documentation to the Official Docs section under the Resources category. This documentation provides comprehensive information about nuxtopen source framework under MIT license that makes web development simple and powerful.**

## Screenshots

<!-- Add all the screenshots which support your changes -->
[Attach screenshots here if applicable]

## Note to Reviewers

Thank you for reviewing this pull request!