### PR TITLE
feat: improve sidebar navigation UI design and structure

### DIFF
--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -21,12 +21,15 @@ export const SideNavbar: FC<{}> = () => {
       <Backdrop onClick={closeNav} className="lg:hidden" />
       {createPortal(
         <div
-          className={`fixed top-0 left-0 z-[100] h-full w-[75%] transition-all lg:hidden
+          className={`fixed top-0 left-0 z-[100] h-full w-[340px] transition-all lg:hidden
           ${sidebar ? 'animate-slide-in' : 'animate-slide-out'}
           `}
         >
           <SideNavbarHeader />
-          <SocialMediaIconsList className="bg-gray-100 px-6 py-2 dark:bg-gray-900" />
+          <SocialMediaIconsList
+            className="bg-gray-100 px-6 py-2 dark:bg-gray-900"
+            showGithubButtons={true} // to show the Star & Fork Button below social media icons
+          />
           <SideNavbarBody />
         </div>,
         document.getElementById('overlay-root')!

--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -21,7 +21,7 @@ export const SideNavbar: FC<{}> = () => {
       <Backdrop onClick={closeNav} className="lg:hidden" />
       {createPortal(
         <div
-          className={`fixed top-0 left-0 z-[100] h-full w-[340px] transition-all lg:hidden
+          className={`fixed top-0 left-0 z-[100] h-full w-[310px] transition-all lg:hidden
           ${sidebar ? 'animate-slide-in' : 'animate-slide-out'}
           `}
         >

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -11,7 +11,7 @@ export const SocialMediaIconsList: FC<{
   const { className, showGithubButtons } = props
 
   return (
-    <ul className={`flex items-center gap-6 ${className}`}>
+    <ul className={`flex flex-wrap gap-6 ${className}`}>
       {!showGithubButtons && (
         <>
           <li className="mr-2 hidden md:block">
@@ -22,64 +22,66 @@ export const SocialMediaIconsList: FC<{
           </li>
         </>
       )}
-      <li>
-        <a
-          title="Link to Discord server (External Link)"
-          className="dark:text-gray-300"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://discord.com/invite/NvK67YnJX5"
-          aria-label="Visit us on Discord"
-        >
-          <IconContext.Provider
-            value={{ className: 'shared-class', size: '24' }}
+      <div className="flex items-center gap-6">
+        <li>
+          <a
+            title="Link to Discord server (External Link)"
+            className="dark:text-gray-300"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://discord.com/invite/NvK67YnJX5"
+            aria-label="Visit us on Discord"
           >
-            <FaDiscord className="hover:text-discord transition duration-300 ease-in-out" />
-          </IconContext.Provider>
-        </a>
-      </li>
-      <li>
-        <a
-          title="Link to Github project (External Link)"
-          className="dark:text-gray-300"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/rupali-codes/LinksHub"
-          aria-label="Visit us on Github"
-        >
-          <IconContext.Provider
-            value={{ className: 'shared-class', size: '24' }}
+            <IconContext.Provider
+              value={{ className: 'shared-class', size: '24' }}
+            >
+              <FaDiscord className="hover:text-discord transition duration-300 ease-in-out" />
+            </IconContext.Provider>
+          </a>
+        </li>
+        <li>
+          <a
+            title="Link to Github project (External Link)"
+            className="dark:text-gray-300"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/rupali-codes/LinksHub"
+            aria-label="Visit us on Github"
           >
-            <FaGithub className="hover:text-github transition duration-300 ease-in-out" />
-          </IconContext.Provider>
-        </a>
-      </li>
-      <li>
-        <a
-          title="Link to Twitter page (External Link)"
-          className="dark:text-gray-300"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://twitter.com/linkshubdotdev"
-          aria-label="Visit us on Twitter"
-        >
-          <IconContext.Provider
-            value={{ className: 'shared-class', size: '24' }}
+            <IconContext.Provider
+              value={{ className: 'shared-class', size: '24' }}
+            >
+              <FaGithub className="hover:text-github transition duration-300 ease-in-out" />
+            </IconContext.Provider>
+          </a>
+        </li>
+        <li>
+          <a
+            title="Link to Twitter page (External Link)"
+            className="dark:text-gray-300"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://twitter.com/linkshubdotdev"
+            aria-label="Visit us on Twitter"
           >
-            <FaTwitter className="hover:text-twitter transition duration-300 ease-in-out" />
-          </IconContext.Provider>
-        </a>
-      </li>
+            <IconContext.Provider
+              value={{ className: 'shared-class', size: '24' }}
+            >
+              <FaTwitter className="hover:text-twitter transition duration-300 ease-in-out" />
+            </IconContext.Provider>
+          </a>
+        </li>
+      </div>
       <li className="flex-1" />
       {showGithubButtons && (
-        <>
+        <div className="flex justify-end">
           <li className="mr-2 hidden md:block">
             <GitHubForkButton repo="rupali-codes/LinksHub" />
           </li>
           <li className="mr-2 hidden md:block">
             <GitHubStarButton repo="rupali-codes/LinksHub" />
           </li>
-        </>
+        </div>
       )}
     </ul>
   )

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -75,10 +75,10 @@ export const SocialMediaIconsList: FC<{
       <li className="flex-1" />
       {showGithubButtons && (
         <div className="flex justify-end">
-          <li className="mr-2 hidden md:block">
+          <li className="mr-2 sm:block">
             <GitHubForkButton repo="rupali-codes/LinksHub" />
           </li>
-          <li className="mr-2 hidden md:block">
+          <li className="mr-2 sm:block">
             <GitHubStarButton repo="rupali-codes/LinksHub" />
           </li>
         </div>

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -14,10 +14,10 @@ export const SocialMediaIconsList: FC<{
     <ul className={`flex flex-wrap gap-6 ${className}`}>
       {!showGithubButtons && (
         <>
-          <li className="mr-2 hidden md:block">
+          <li className="pt-6 hidden md:block">
             <GitHubForkButton repo="rupali-codes/LinksHub" />
           </li>
-          <li className="mr-2 hidden md:block">
+          <li className="mr-2 pt-6 hidden md:block">
             <GitHubStarButton repo="rupali-codes/LinksHub" />
           </li>
         </>
@@ -72,10 +72,9 @@ export const SocialMediaIconsList: FC<{
           </a>
         </li>
       </div>
-      <li className="flex-1" />
       {showGithubButtons && (
-        <div className="flex justify-end">
-          <li className="mr-2 sm:block">
+        <div className="flex">
+          <li className="mr-4 sm:block">
             <GitHubForkButton repo="rupali-codes/LinksHub" />
           </li>
           <li className="mr-2 sm:block">

--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -4,17 +4,24 @@ import { FaDiscord, FaGithub, FaTwitter } from 'react-icons/fa'
 import { GitHubForkButton } from 'components/ForkButton/GitHubForkButton'
 import { GitHubStarButton } from 'components/StarButton/GitHubStarButton'
 
-export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
-  const { className } = props
+export const SocialMediaIconsList: FC<{
+  className?: string
+  showGithubButtons?: boolean
+}> = (props) => {
+  const { className, showGithubButtons } = props
 
   return (
     <ul className={`flex items-center gap-6 ${className}`}>
-      <li className="mr-2 hidden md:block">
-        <GitHubForkButton repo="rupali-codes/LinksHub" />
-      </li>
-      <li className="mr-2 hidden md:block">
-        <GitHubStarButton repo="rupali-codes/LinksHub" />
-      </li>
+      {!showGithubButtons && (
+        <>
+          <li className="mr-2 hidden md:block">
+            <GitHubForkButton repo="rupali-codes/LinksHub" />
+          </li>
+          <li className="mr-2 hidden md:block">
+            <GitHubStarButton repo="rupali-codes/LinksHub" />
+          </li>
+        </>
+      )}
       <li>
         <a
           title="Link to Discord server (External Link)"
@@ -63,6 +70,17 @@ export const SocialMediaIconsList: FC<{ className?: string }> = (props) => {
           </IconContext.Provider>
         </a>
       </li>
+      <li className="flex-1" />
+      {showGithubButtons && (
+        <>
+          <li className="mr-2 hidden md:block">
+            <GitHubForkButton repo="rupali-codes/LinksHub" />
+          </li>
+          <li className="mr-2 hidden md:block">
+            <GitHubStarButton repo="rupali-codes/LinksHub" />
+          </li>
+        </>
+      )}
     </ul>
   )
 }


### PR DESCRIPTION
## Fixes Issue

Resolves #1166 

## Changes proposed

- Please check the deployed URL.
- As suggested, I have positioned the GitHub stats button on the next line after the social icons and reduced the width of the side navbar.

> Suggestion
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/699c89a3-bfd0-4c36-ae8c-dd040be4e1d1)

## Note to reviewers

Please answer this: https://github.com/rupali-codes/LinksHub/issues/500#issuecomment-1627696522
so that I can begin working on maintainers section.