### PR TITLE
feat: show maintainers/contributors state in contributors section

### DIFF
--- a/data/maintainersData.ts
+++ b/data/maintainersData.ts
@@ -1,0 +1,5 @@
+export const maintainersData = [
+  { login: 'rupali-codes', name: 'Rupali Codes' },
+  { login: 'CBID2', name: 'CBID2' },
+  { login: 'ujjawaltyagii', name: 'Ujjawal Tyagi' },
+]

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import type { GetStaticProps } from 'next'
 import { useTheme } from 'next-themes'
 import { maintainersData } from '../data/maintainersData'
+import { useState } from 'react'
 
 interface Contributor {
   id: number
@@ -63,6 +64,7 @@ export const getStaticProps: GetStaticProps<{
 const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
   contributors,
 }) => {
+  const [hovered, setHovered] = useState(false)
   const { resolvedTheme } = useTheme()
   const filteredContributors = contributors.filter(
     (contributor) => contributor.contributions >= 6
@@ -103,13 +105,23 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
                 height={80}
                 className=" rounded-full mb-4"
               />
-              <span className={imageInfo}>
+              <span
+                className={imageInfo}
+                onMouseEnter={() => setHovered(true)}
+                onMouseLeave={() => setHovered(false)}
+              >
                 {maintainersData.some(
                   (data) => data.login === contributor.login
                 ) ? (
-                  <span className="hidden sm:inline">Maintainer</span>
-                ) : (
+                  hovered ? (
+                    <span className="hidden sm:inline">Maintainer</span>
+                  ) : (
+                    <span>M</span>
+                  )
+                ) : hovered ? (
                   <span className="hidden sm:inline">Contributor</span>
+                ) : (
+                  <span>C</span>
                 )}
               </span>
             </div>

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -31,7 +31,6 @@ export const getStaticProps: GetStaticProps<{
           const response = await fetch(
             `https://api.github.com/users/${contributor.login}`
           )
-          console.log(contributor.login)
           if (response.ok) {
             const data = await response.json()
             const updatedContributor: Contributor = {
@@ -64,7 +63,7 @@ export const getStaticProps: GetStaticProps<{
 const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
   contributors,
 }) => {
-  const [hovered, setHovered] = useState(false)
+  const [hoveredContributor, setHoveredContributor] = useState<string>('')
   const { resolvedTheme } = useTheme()
   const filteredContributors = contributors.filter(
     (contributor) => contributor.contributions >= 6
@@ -107,19 +106,19 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
               />
               <span
                 className={imageInfo}
-                onMouseEnter={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
+                onMouseEnter={() => setHoveredContributor(contributor.login)}
+                onMouseLeave={() => setHoveredContributor('')}
               >
                 {maintainersData.some(
                   (data) => data.login === contributor.login
                 ) ? (
-                  hovered ? (
-                    <span className="hidden sm:inline">Maintainer</span>
+                  hoveredContributor === contributor.login ? (
+                    <span>Maintainer</span>
                   ) : (
                     <span>M</span>
                   )
-                ) : hovered ? (
-                  <span className="hidden sm:inline">Contributor</span>
+                ) : hoveredContributor === contributor.login ? (
+                  <span>Contributor</span>
                 ) : (
                   <span>C</span>
                 )}

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import type { GetStaticProps } from 'next'
 import { useTheme } from 'next-themes'
+import { maintainersData } from '../data/maintainersData'
 
 interface Contributor {
   id: number
@@ -82,7 +83,7 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
 
   const isDarkMode = resolvedTheme === 'dark'
 
-  const imageInfo = `image-effect w-9 h-9 rounded-full bg-gray-100 border ${
+  const imageInfo = `image-effect w-9 h-9 rounded-full bg-gray-100 border text-xl text-gray-900 pl-[9px] pt-1 ${
     isDarkMode ? '' : 'border-dashed border-violet-400'
   }`
 
@@ -102,7 +103,14 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
                 height={80}
                 className=" rounded-full mb-4"
               />
-              <span className={imageInfo}></span>
+              <span className={imageInfo}>
+                {maintainersData.some(
+                  (data) => data.login === contributor.login
+                )
+                  ? 'M'
+                  : 'C'}
+                {/* ['rupali-codes', 'CBID2', 'Anmol-Baranwal'] - We can also use this */}
+              </span>
             </div>
             <div className="text-center">
               <div className="text-xl text-violet-600 dark:text-violet-400">

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import type { GetStaticProps } from 'next'
+import { useTheme } from 'next-themes'
 
 interface Contributor {
   id: number
@@ -28,6 +29,7 @@ export const getStaticProps: GetStaticProps<{
           const response = await fetch(
             `https://api.github.com/users/${contributor.login}`
           )
+          console.log(contributor.login)
           if (response.ok) {
             const data = await response.json()
             const updatedContributor: Contributor = {
@@ -60,6 +62,7 @@ export const getStaticProps: GetStaticProps<{
 const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
   contributors,
 }) => {
+  const { resolvedTheme } = useTheme()
   const filteredContributors = contributors.filter(
     (contributor) => contributor.contributions >= 6
   )
@@ -77,6 +80,12 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
     className: buttonStyles,
   }
 
+  const isDarkMode = resolvedTheme === 'dark'
+
+  const imageInfo = `image-effect w-9 h-9 rounded-full bg-gray-100 border ${
+    isDarkMode ? '' : 'border-dashed border-violet-400'
+  }`
+
   return (
     <div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -85,7 +94,7 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
             key={contributor.id}
             className="bg-gray-100 rounded-3xl py-5 px-2 border border-dashed border-violet-500 dark:border-violet-400 shadow-lg dark:bg-gray-900 dark:text-gray-300 dark:shadow-sm flex flex-col"
           >
-            <div className="flex justify-center">
+            <div className="flex justify-center image-wrapper">
               <Image
                 src={contributor.avatar_url}
                 alt={contributor.login}
@@ -93,6 +102,7 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
                 height={80}
                 className=" rounded-full mb-4"
               />
+              <span className={imageInfo}></span>
             </div>
             <div className="text-center">
               <div className="text-xl text-violet-600 dark:text-violet-400">

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -83,9 +83,9 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
 
   const isDarkMode = resolvedTheme === 'dark'
 
-  const imageInfo = `image-effect w-9 h-9 rounded-full bg-gray-100 border text-xl text-gray-900 pl-[9px] pt-1 ${
+  const imageInfo = `image-effect w-9 h-9 rounded-full bg-gray-100 border text-lg text-gray-900 pl-[9px] pt-1 ${
     isDarkMode ? '' : 'border-dashed border-violet-400'
-  }`
+  } `
 
   return (
     <div>
@@ -106,10 +106,11 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
               <span className={imageInfo}>
                 {maintainersData.some(
                   (data) => data.login === contributor.login
-                )
-                  ? 'M'
-                  : 'C'}
-                {/* ['rupali-codes', 'CBID2', 'Anmol-Baranwal'] - We can also use this */}
+                ) ? (
+                  <span className="hidden sm:inline">Maintainer</span>
+                ) : (
+                  <span className="hidden sm:inline">Contributor</span>
+                )}
               </span>
             </div>
             <div className="text-center">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -181,15 +181,9 @@ pre {
 }
 
 .image-effect {
-  position: absolute;
+  position: relative;
   top: 20px;
-  right: 90px;
-  /* font-size: 1rem; */
-  /* width: 20px; */
-  /* height: 20px; */
-}
-
-.image-effect span:not(:hover) {
+  right: 15px;
 }
 
 .image-effect:hover span {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,6 +184,25 @@ pre {
   position: absolute;
   top: 20px;
   right: 90px;
+  /* font-size: 1rem; */
   /* width: 20px; */
   /* height: 20px; */
+}
+
+.image-effect span:not(:hover) {
+}
+
+.image-effect:hover span {
+  position: absolute;
+  top: -2px;
+  left: -1px;
+  white-space: nowrap;
+  padding: 0.3rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: #6b46c1;
+  color: white;
+  border-radius: 2rem;
+  border-top-left-radius: 2rem;
+  border-bottom-left-radius: 2rem;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -170,8 +170,20 @@ pre {
   scrollbar-width: thin;
   scrollbar-color: var(--scroll-thumb) var(--scroll-track);
 }
-@media (min-width:597px) and (max-width:800px){
-    .grid-cols-1 {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (min-width: 597px) and (max-width: 800px) {
+  .grid-cols-1 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  }
+}
+
+.image-wrapper {
+  position: relative;
+}
+
+.image-effect {
+  position: absolute;
+  top: 20px;
+  right: 90px;
+  /* width: 20px; */
+  /* height: 20px; */
+}


### PR DESCRIPTION
## Fixes Issue

Closes #1300

> I created a new issue, because I believe we need to implement one more section just for maintainers.

## Screenshots

Same for maintainers, showing `M` and for Contributors showing `C`

I implemented the hover part, because tool tip would not be great for custom styling.

> Hover
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/82839952-0225-4c3d-ab59-37185d150c0b)

> Normal
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/d62ae0c9-3c8b-4d4d-a857-6f5f3cc276fb)

## Note to reviewers

@rupali-codes 
This should be a level 3 PR since it was very tough to implement and it's a new feature.