### PR TITLE
fix: warning due to any non-nullish value

### DIFF
--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -13,7 +13,7 @@ export const SideNavbarBody: FC = () => {
   return (
     <div
       className={classNames(
-        `bg-base-200 h-full w-full overflow-x-hidden whitespace-nowrap transition-all transition-none ease-in dark:bg-gray-900 dark:text-gray-300`,
+        `bg-base-200 h-full w-full overflow-x-hidden whitespace-nowrap transition-all ease-in dark:bg-gray-900 dark:text-gray-300`,
         theme === 'light' ? 'scrollColorLight' : 'scrollColorDark'
       )}
     >

--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { useTheme } from 'next-themes'
 import { SideNavbarCategoryList } from './SideNavbarCategoryList'
 
-export const SideNavbarBody: FC<{}> = () => {
+export const SideNavbarBody: FC = () => {
   const { theme } = useTheme()
 
   const { setSearch, searchResults, debouncedSearch } = useSidebarSearch()


### PR DESCRIPTION
## Fixes Issue

Closes #1309 

## Changes proposed

> Fixed warning
![warning](https://user-images.githubusercontent.com/74038190/253818218-0ea21eb0-9428-4ee5-92f7-39a70394d764.png)

## Note to reviewers

I was confused because the CSS classes `transition-all` and `transition-none` are used together in the same line. I need clarification on whether you want to keep both classes or remove one of them. Please let me know your preference so that I can make the change.

```css
transition-all transition-none
```

![image](https://github.com/rupali-codes/LinksHub/assets/74038190/01557304-30c7-4715-8d02-df3a5a6cf463)
