### PR TITLE
revamp: hover states of social icons ✨

### DIFF
--- a/components/SocialMedia/SocialMediaIconsList.tsx
+++ b/components/SocialMedia/SocialMediaIconsList.tsx
@@ -35,7 +35,7 @@ export const SocialMediaIconsList: FC<{
             <IconContext.Provider
               value={{ className: 'shared-class', size: '24' }}
             >
-              <FaDiscord className="hover:text-discord transition duration-300 ease-in-out" />
+              <FaDiscord className="hover:text-violet-500 transition duration-300 ease-in-out" />
             </IconContext.Provider>
           </a>
         </li>
@@ -51,7 +51,7 @@ export const SocialMediaIconsList: FC<{
             <IconContext.Provider
               value={{ className: 'shared-class', size: '24' }}
             >
-              <FaGithub className="hover:text-github transition duration-300 ease-in-out" />
+              <FaGithub className="hover:text-violet-500 transition duration-300 ease-in-out" />
             </IconContext.Provider>
           </a>
         </li>
@@ -67,7 +67,7 @@ export const SocialMediaIconsList: FC<{
             <IconContext.Provider
               value={{ className: 'shared-class', size: '24' }}
             >
-              <FaTwitter className="hover:text-twitter transition duration-300 ease-in-out" />
+              <FaTwitter className="hover:text-violet-500 transition duration-300 ease-in-out" />
             </IconContext.Provider>
           </a>
         </li>
@@ -85,9 +85,3 @@ export const SocialMediaIconsList: FC<{
     </ul>
   )
 }
-
-// colors: {
-//   discord: '#7289DA',
-//   github: '#211F1F',
-//   twitter: '#1DA1F2',
-// },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,11 +7,6 @@ module.exports = {
   ],
   theme: {
     extend: {
-      colors: {
-        discord: '#7289DA',
-        github: '#211F1F',
-        twitter: '#1DA1F2',
-      },
       screens: {
         xs: '200px',
       },


### PR DESCRIPTION
## Fixes Issue
Close #1299 

## Changes proposed
- Revamped the hover states of all icons to the site's primary violet color `#8B5CF6`
- Removed the unnecessary color codes after revamping the hover states so that we could clean the old ones.

## Screenshots

https://github.com/rupali-codes/LinksHub/assets/92252895/bb823f7f-64ef-482c-9aab-f5e38be6e5bd