### PR TITLE
Bug fix in Data Structures 

### DIFF
--- a/database/data.ts
+++ b/database/data.ts
@@ -161,7 +161,7 @@ export const sidebarData: ISidebar[] = [
       { name: 'CSS', url: '/css', resources: DB.css },
       { name: 'machine learning', url: '/machine-learning', resources: DB.machineLearning },
       { name: 'tensorflow', url: '/tensorflow', resources: DB.tensorflow },
-      { name: 'data structures', url: '/dsa', resources: DB.dataStructures },
+      { name: 'data structures', url: '/data-structures', resources: DB.dataStructures },
       { name: 'Android', url: '/android', resources: DB.android },
       {
         name: 'Web3 & Metaverse',


### PR DESCRIPTION
## Fixes Issue 
Closes #1287
### I have just fixed an issue in the 'YouTube' category under the 'Data Structures' subcategory.

I raised an issue to add a new link, but it turned out that there was already a link for that. The problem was in the `data.ts` file, where they mentioned `dsa` in the URL instead of `data-structures`, causing it to redirect to `dsa`. I simply replaced `dsa` with `data-structures`, and now it works perfectly for me.

**My question:** Is it okay to make this change only in the `data.ts` file, or should I update the subcategory for all the links present in `data-structures.json"?
