### PR TITLE
Adding Kaggle site.

### DIFF
--- a/database/machine_learning/data-science.json
+++ b/database/machine_learning/data-science.json
@@ -22,7 +22,7 @@
   },
   {
     "name": "Kaggle",
-    "description": "Kaggle is a data science competition platform and online community of data scientists and machine learning practitioners under Google.",
+    "description": "Kaggle is an online platform that hosts data science competitions. It's also where data scientists and machine learning practitioners worldwide come and network with each other.",
     "url": "https://www.kaggle.com/",
     "category": "ml & ai",
     "subcategory": "data-science"

--- a/database/machine_learning/data-science.json
+++ b/database/machine_learning/data-science.json
@@ -19,5 +19,12 @@
     "url": "https://www.analyticsvidhya.com/",
     "category": "ml & ai",
     "subcategory": "data-science"
+  },
+  {
+    "name": "Kaggle",
+    "description": "Kaggle is a data science competition platform and online community of data scientists and machine learning practitioners under Google.",
+    "url": "https://www.kaggle.com/",
+    "category": "ml & ai",
+    "subcategory": "data-science"
   }
 ]


### PR DESCRIPTION

Closes #1273

## Changes proposed

Kaggle is a data science competition platform and online community of data scientists and machine learning practitioners under Google.

## Screenshots
![Screenshot 2023-07-27 231907](https://github.com/rupali-codes/LinksHub/assets/92087279/18e18ab3-21f9-4924-8088-649b40fc2123)


