### PR TITLE
feat: remove redundant code and add styling

### DIFF
--- a/components/ForkButton/GitHubForkButton.tsx
+++ b/components/ForkButton/GitHubForkButton.tsx
@@ -28,9 +28,7 @@ export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
       rel="noopener noreferrer"
       aria-label={`Fork ${repo} on GitHub`}
     >
-      <div
-        className="inline-flex items-center py-1 text-sm font-semibold bg-transparent text-theme-secondary rounded-sm transition-colors transition duration-300 ease-in-out hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary"
-      >
+      <div className="inline-flex items-center px-4 py-1 text-sm font-semibold bg-transparent border border-violet-500 border-transparent shadow-md text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
         <FaCodeBranch className="mr-1" />
         <span className="font-semibold">Fork</span>
         <span className="ml-2">{forkCount}</span>

--- a/components/ForkButton/GitHubForkButton.tsx
+++ b/components/ForkButton/GitHubForkButton.tsx
@@ -28,7 +28,7 @@ export const GitHubForkButton: FC<{ repo: string }> = ({ repo }) => {
       rel="noopener noreferrer"
       aria-label={`Fork ${repo} on GitHub`}
     >
-      <div className="inline-flex items-center px-4 py-1 text-sm font-semibold bg-transparent border border-violet-500 border-transparent shadow-md text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
+      <div className="inline-flex items-center py-1 text-sm font-semibold bg-transparent text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
         <FaCodeBranch className="mr-1" />
         <span className="font-semibold">Fork</span>
         <span className="ml-2">{forkCount}</span>

--- a/components/StarButton/GitHubStarButton.tsx
+++ b/components/StarButton/GitHubStarButton.tsx
@@ -28,8 +28,7 @@ export const GitHubStarButton: FC<{ repo: string }> = ({ repo }) => {
       rel="noopener noreferrer"
       aria-label={`Star ${repo} on GitHub`}
     >
-      <div className="inline-flex items-center px-4 py-1 text-sm font-semibold bg-transparen border border-dashed border-transparent shadow-md text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
-        {/* <div className="inline-flex items-center px-4 py-1 text-sm bg-violet-500 text-white border border-dashed border-transparent rounded-sm transition-colors shadow-md hover:bg-transparent hover:border-violet-400 hover:text-violet-400"> */}
+      <div className="inline-flex items-center py-1 text-sm font-semibold bg-transparent text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
         <FaRegStar className="mr-1" />
         <span>Star</span>
         <span className="ml-2">{starCount}</span>

--- a/components/StarButton/GitHubStarButton.tsx
+++ b/components/StarButton/GitHubStarButton.tsx
@@ -28,7 +28,8 @@ export const GitHubStarButton: FC<{ repo: string }> = ({ repo }) => {
       rel="noopener noreferrer"
       aria-label={`Star ${repo} on GitHub`}
     >
-      <div className="inline-flex items-center py-1 text-sm font-semibold bg-transparent text-theme-secondary rounded-sm transition-colors transition duration-300 ease-in-out hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
+      <div className="inline-flex items-center px-4 py-1 text-sm font-semibold bg-transparen border border-dashed border-transparent shadow-md text-theme-secondary rounded-sm hover:text-text-secondary transition duration-300 ease-in-out dark:hover:text-text-primary dark:text-theme-primary">
+        {/* <div className="inline-flex items-center px-4 py-1 text-sm bg-violet-500 text-white border border-dashed border-transparent rounded-sm transition-colors shadow-md hover:bg-transparent hover:border-violet-400 hover:text-violet-400"> */}
         <FaRegStar className="mr-1" />
         <span>Star</span>
         <span className="ml-2">{starCount}</span>


### PR DESCRIPTION
## Fixes Issue

Closes #1410 

## Changes proposed

@rupali-codes 

There was redundant code in the Tailwind styling, so even if you don't need the border, you can definitely merge this.

> duplicate code
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/70667c87-d69d-4a41-9437-0e0d3dcc3fc9)


If you want a border, let me know so that I can make the change with `GitHubStarButton`. If you don't want a border, then I will remove the extra code.

Please let me know your decision.