### PR TITLE
feat: add referral of LinksHub in the URL

### DIFF
--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -1,7 +1,7 @@
 import { FC, useState, useRef, useEffect } from 'react'
 import { BsBoxArrowUpRight } from 'react-icons/bs'
 import { CopyToClipboard } from 'components/CopyToClipboard'
-import { Share } from 'components/Share';
+import { Share } from 'components/Share'
 import type { IData } from 'types'
 
 interface CardProps {
@@ -34,7 +34,7 @@ const Card: FC<CardProps> = ({ data }) => {
           </h2>
           <div className="flex items-center gap-1">
             <CopyToClipboard url={url} />
-            <Share url={url} title={name} />
+            <Share url={`${url}?ref=LinksHub`} title={name} />
           </div>
         </header>
         <div className="h-[7rem]">


### PR DESCRIPTION
## Fixes Issue

Closes #1421 

## Changes proposed

- I don't know why it happened, but when I checked yesterday multiple times, it was showing the wrong URL, while it is correct as of now.
- So, what we can do is add `?ref=LinksHub` to let people know that the traffic is coming from LinksHub.

> This works whenever we copy the link.

## Screenshots

![image](https://github.com/rupali-codes/LinksHub/assets/74038190/00e4d732-6079-497b-9648-e3cbf2d78fae)
