### PR TITLE
feat: make search bar sticky and adjust scrollable area

### DIFF
--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -7,26 +7,26 @@ import { SideNavbarCategoryList } from './SideNavbarCategoryList'
 
 export const SideNavbarBody: FC = () => {
   const { theme } = useTheme()
-
   const { setSearch, searchResults, debouncedSearch } = useSidebarSearch()
 
   return (
-    <div
-      className={classNames(
-        `bg-[rgba(255,255,255,0.3)] h-full w-full overflow-x-hidden whitespace-nowrap transition-all ease-in dark:bg-dark dark:text-text-primary`,
-        theme === 'light' ? 'scrollColorLight' : 'scrollColorDark'
-      )}
-    >
-      <div className="search-sticky-top">
-        <div className="bg-light-primary transiton-all w-full p-4 transition-none ease-in dark:bg-dark">
-          <Searchbar setSearch={setSearch} />
-        </div>
+    <div className="bg-[rgba(255,255,255,0.3)] w-full overflow-x-hidden whitespace-nowrap transition-all ease-in dark:bg-dark dark:text-text-primary">
+      <div className="bg-light-primary p-4 transition-all ease-in dark:bg-dark">
+        <Searchbar setSearch={setSearch} />
       </div>
-      <SideNavbarCategoryList
-        items={searchResults}
-        isSearching={debouncedSearch.length > 0}
-        openByDefault={''}
-      />
+
+      <div
+        className={classNames(
+          theme === 'light' ? 'scrollColorLight' : 'scrollColorDark'
+        )}
+        style={{ maxHeight: 'calc(100vh - 4rem)' }}
+      >
+        <SideNavbarCategoryList
+          items={searchResults}
+          isSearching={debouncedSearch.length > 0}
+          openByDefault={''}
+        />
+      </div>
     </div>
   )
 }

--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -17,8 +17,10 @@ export const SideNavbarBody: FC = () => {
         theme === 'light' ? 'scrollColorLight' : 'scrollColorDark'
       )}
     >
-      <div className="bg-primary-light transiton-all w-full p-4 transition-none ease-in dark:bg-dark">
-        <Searchbar setSearch={setSearch} />
+      <div className="search-sticky-top">
+        <div className="bg-light-primary transiton-all w-full p-4 transition-none ease-in dark:bg-dark">
+          <Searchbar setSearch={setSearch} />
+        </div>
       </div>
       <SideNavbarCategoryList
         items={searchResults}

--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -11,7 +11,7 @@ export const SideNavbarBody: FC = () => {
 
   return (
     <div className="bg-[rgba(255,255,255,0.3)] w-full overflow-x-hidden whitespace-nowrap transition-all ease-in dark:bg-dark dark:text-text-primary">
-      <div className="bg-light-primary p-4 transition-all ease-in dark:bg-dark">
+      <div className="bg-light-primary p-4 pt-0 transition-all ease-in dark:bg-dark">
         <Searchbar setSearch={setSearch} />
       </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,9 +184,3 @@ pre {
   border-top-left-radius: 2rem;
   border-bottom-left-radius: 2rem;
 }
-
-.search-sticky-top {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,3 +184,9 @@ pre {
   border-top-left-radius: 2rem;
   border-bottom-left-radius: 2rem;
 }
+
+.search-sticky-top {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}


### PR DESCRIPTION
## Fixes Issue

Closes #1418 

## Changes proposed

> Why search bar should be sticky.

- Users can keep their search query visible while exploring different categories. This helps them remember their search context and makes it easy to refine or modify their search without losing sight of the results.
- With a sticky search bar, users can focus on interacting with the search input without distractions, as it remains in a fixed position regardless of their scrolling behavior.

## Screenshots

> Sticky search bar
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/ce120586-8255-4ef7-a902-376994a64b9f)

## Note to reviewers

- I initially attempted different styling approaches but later changed my approach after trying various options, as this one appeared to be the most sophisticated and easy to understand.