### PR TITLE
feat: implement prefers reduced motion feature to enhance accessibility 🚀✨ 

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,3 +184,39 @@ pre {
   border-top-left-radius: 2rem;
   border-bottom-left-radius: 2rem;
 }
+
+/* This media query targets devices or browsers that have enabled reduced motion preferences.
+   It ensures that animations and transitions are minimized to improve user experience for motion-sensitive users.
+*/
+@media (prefers-reduced-motion: reduce) {
+  /* Apply the following styles to all elements */
+  *,
+  /* Apply the following styles to all pseudo-elements (::before, ::after) */
+  ::before,
+  ::after {
+    /* Disables animations by setting a negative animation delay and duration.
+       This effectively cancels any animations on the page.
+    */
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    animation: none !important;
+
+      /* Disables background-attachment: fixed, which prevents elements with fixed backgrounds from remaining in place while scrolling.
+       This reduces the perception of motion when scrolling.
+      */
+    background-attachment: initial !important;
+    
+      /* Reverts scroll-behavior to its default value 'auto', which prevents smooth scrolling behavior.
+         Smooth scrolling may cause discomfort to motion-sensitive users.
+      */
+    scroll-behavior: auto !important;
+    
+      /* Sets transition duration and delay to 0 seconds, effectively disabling all transitions.
+         This prevents any element from animating when its properties change.
+      */
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Fixes Issue

Close #1478 

## Changes proposed
- I'm excited to propose a pull request that enhances the accessibility of our Linkshub repository. In this PR, I've introduced reduced motion styles to accommodate users who have enabled the "prefers-reduced-motion" setting in their devices or browsers.
- To improve the user experience for motion-sensitive users, I've implemented a media query in `global.css` to target devices with reduced motion preferences. The following enhancements have been made:

  - **Minimized Animations**: By targetting`animation` property for all elements, pseudo-elements (::before, ::after), and transitions, we effectively cancel any animations on the page.
  
  - **Reduced Transitions**: By targetting `transition` property, all transitions are disabled, ensuring that elements don't animate when their properties change.
  
  - **Optimized Background Attachment**: I've set `background-attachment: initial` to prevent elements with fixed backgrounds from moving while scrolling, reducing the perception of motion.
  
  - **Improved Scroll Behavior**: By reverting `scroll-behavior` to its default value `auto`, smooth scrolling behavior is disabled, which can be discomforting for motion-sensitive users.

## Why This Matters
- Prioritizing accessibility is essential in creating an inclusive experience for all users. With reduced motion styles, we're catering to users who may have motion sensitivity or motion-related disabilities. 
- These enhancements align with our commitment to making Linkshub accessible to a diverse audience.

## Screenshots

https://github.com/rupali-codes/LinksHub/assets/92252895/3a32332d-72f7-4b1d-804b-06294d0200fb


## Note to reviewers
- You can test this feature on,
  - Windows 10: Settings > Ease of Access > Display > Show animations in Windows.
  - Windows 11: Settings > Accessibility > Visual Effects > Animation Effects
  - macOS: System Preferences > Accessibility > Display > Reduce motion.
  - iOS: Settings > Accessibility > Motion.
  - Android 9+: Settings > Accessibility > Remove animations.
  - Firefox about:config: Add a number preference called ui.prefersReducedMotion and set its value to either 0 for full animation or to 1 to indicate a preference for reduced motion. Changes to this preference take effect immediately.
  - Chrome: go to "Settings" > "Advanced" > "Accessibility." Under the "Display" section, enable the "Prefer reduced motion" option.
