### PR TITLE
search query

### DIFF
--- a/hooks/useSidebarSearch.ts
+++ b/hooks/useSidebarSearch.ts
@@ -29,6 +29,9 @@ function useSidebarSearch() {
           query: debouncedSearch,
         },
       })
+    }else {
+      // Clear the query when search bar is empty and handle reload issue
+      router.push('/search', undefined, { shallow: true })
     }
   }, [debouncedSearch])
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes 
Closes #1518 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
In our original code, we implemented a custom hook named useSidebarSearch to manage the functionality of searching within the sidebar. We encountered an issue where the search query remained in the URL even after users cleared the search bar. Our objective was to address this issue and ensure that the query parameter would be removed from the URL when the search bar was empty.

To tackle this problem, we introduced an else block within the `useEffect` of the `useSidebarSearch` hook. Within this else block, we checked whether the debouncedSearch (the search query) had a length greater than 0. If it did not, we used the `router.push` function to navigate to the same /search route, employing specific options:

We utilized `undefined` as the second argument. By doing so, we effectively cleared the existing query parameter from the URL.
We employed `shallow: true` as the third argument in order to ensure that the navigation remained shallow. This prevented the unmounting and remounting of page components, effectively avoiding a complete page reload.
By incorporating this else block, we successfully managed the scenario where the search bar was empty. Consequently, we were able to remove the query parameter from the URL. This resolution effectively addressed the issue of the search query persisting in the URL even after users cleared the search bar.

In summary, the modifications we made to the `useEffect` within the `useSidebarSearch` hook included an else block that efficiently cleared the query parameter from the URL when the search bar was empty. This modification successfully resolved the issue we encountered with the search query lingering in the URL.

<!-- List all the proposed changes in your PR -->

## Screenshots


https://github.com/rupali-codes/LinksHub/assets/96341431/95797b5b-abd8-49bb-b4a0-562977c2b259



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->