### PR TITLE
feat: added automation for drafting a release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,27 +6,27 @@ categories:
       - "📈 Major"
   - title: "🚀 New Features"
     labels:
-      - "🛠 Feature"
+      - "feature"
   - title: "🐛 Bug Fixes"
     labels:
-      - "🐞 Bug"
+      - "patch"
       - "📄 aspect: docs"
   - title: "🧰 Maintenance"
     labels: 
       - "chore"
       - "dependencies"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&' 
 version-resolver:
   major:
     labels:
       - "📈 Major"
   minor:
     labels:
-      - "🛠 Feature"
+      - "feature"
   patch:
     labels:
-      - "🐞 Bug"
+      - "patch"
       - "dependencies"
       - "📄 aspect: docs"
   default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚧 Huge Updates"
+    labels:
+      - "📈 Major"
+  - title: "🚀 New Features"
+    labels:
+      - "🛠 Feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "🐞 Bug"
+      - "📄 aspect: docs"
+  - title: "🧰 Maintenance"
+    labels: 
+      - "chore"
+      - "dependencies"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "📈 Major"
+  minor:
+    labels:
+      - "🛠 Feature"
+  patch:
+    labels:
+      - "🐞 Bug"
+      - "dependencies"
+      - "📄 aspect: docs"
+  default: patch
+template: |
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,35 @@
+name: 📢 Draft Release Notes
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+
+        # The GITHUB_TOKEN works for the most case if it doesnot works, replace it with Personal Access Token
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fixes Issue

Closes #1601 

## Changes proposed

New automation has been added for drafting a release, on pushes/PR merges to the `main` branch and based on a custom template `.github\release-drafter.yml`, release notes will be generated automatically and the versions will be bumped accordingly. 