### PR TITLE
fix: exact match for subcategory

### DIFF
--- a/hooks/useFilterDB.ts
+++ b/hooks/useFilterDB.ts
@@ -12,8 +12,10 @@ const useFilterDB = (): IUseFilterDBResponse => {
   }
   // This filters trough the DB with the subcategory which results in an array of arrays
   const filterSubCat = database?.map((item) =>
-    item?.filter((cat: IData) => cat.subcategory.includes(subcategory))
+    item?.filter((cat: IData) => cat.subcategory === subcategory)
   )
+
+
 
   // This filters out an empty array from the filterSubCat
   const filterDB = filterSubCat?.filter((item) => item.length !== 0)


### PR DESCRIPTION
## Fixes Issue

Closes #1616 

## Changes proposed

Used `===` for exact match

## Screenshots

![image](https://github.com/rupali-codes/LinksHub/assets/55444468/397a8d40-63e4-482d-8b7a-41f5b9839915)


## Note to reviewers

