### PR TITLE
Fix/searchbar accessibility

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -74,11 +74,11 @@ export const Searchbar: React.FC<SearchbarProps> = ({
   }, [dispatchSearch])
 
   return (
-    <form noValidate ref={formRef} onSubmit={handleSubmit}>
+    <form noValidate ref={formRef} onSubmit={handleSubmit} role="search">
       <div className="relative">
-        <div className="flex items-center" role="search">
+        <div className="flex items-center">
           <label htmlFor="simple-search" className="sr-only">
-            Quickly search any resources
+            Quick search
           </label>
           <input
             type="text"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

Closes #1386 

## Changes proposed

The issue was to add an aria label to the search box. I checked with a screen reader and this was not necessary as it already has a screen reader only label. However, I moved the role=search to the form element which is the expected place and made sure the screen reader only label matches the visible placeholder text as this will make sure it's also usable by voice only users.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->