### PR TITLE
feat: make screen non-scrollable in mobile view when sidebar is open

### DIFF
--- a/layouts/GeneralLayout.tsx
+++ b/layouts/GeneralLayout.tsx
@@ -5,13 +5,23 @@ import { Header } from 'components/Header/Header'
 import { Aside } from 'components/Aside/Aside'
 import { SkipLink } from 'components/SkipLink/SkipLink'
 
+import { useContext } from 'react'
+import { IContext } from 'types'
+import { GlobalContext } from 'context/GlobalContext'
+
 const GeneralLayout = ({ children }: { children: ReactNode }) => {
+  const { sidebar } = useContext<IContext>(GlobalContext)
+
   return (
     <>
       <SkipLink />
       <Header />
       <SideNavbar />
-      <div className="row-start-2 row-end-3 min-h-[100vh-72px] w-full bg-gray-100 dark:bg-[#101623]">
+      <div
+        className={`row-start-2 row-end-3 min-h-[100vh-72px] w-full bg-gray-100 dark:bg-[#101623] ${
+          sidebar ? 'max-[1024px]:overflow-hidden' : ''
+        }`}
+      >
         <nav>
           <Aside />
         </nav>


### PR DESCRIPTION
@Anmol-Baranwal 


## Fixes Issue #1619 

## Changes proposed
When the sidebar is open in mobile view, the main content behind the sidebar should remain fixed and not scroll.




