### PR TITLE
Top bar distinction feature

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -7,13 +7,23 @@ import { ThemeToggler } from '../ThemeToggler/themeToggler'
 import { TopBar } from '../TopBar/TopBar'
 import { SocialMediaIconsList } from 'components/SocialMedia/SocialMediaIconsList'
 import { useResults } from 'hooks/ResultsContext'
+import clsx from 'clsx'
+import { usePathname } from 'next/navigation'
 
 export const Header: FC = () => {
   const { toggleNav } = useContext(GlobalContext)
   const { results } = useResults()
+  const pathname = usePathname()
 
   return (
-    <header className="fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark">
+    <header
+      className={clsx(
+        'fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary',
+
+        pathname != '/' &&
+          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary lg:shadow-none transition-color ease-in-out duration-150'
+      )}
+    >
       <div className="bg-light-primary h-full w-fit flex-none px-6 py-4 dark:bg-dark lg:w-[290px]">
         <Link href="/" aria-label="LinksHub Logo">
           <Logo className="text-3xl" />

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export const Header: FC = () => {
         'fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary',
 
         pathname != '/' &&
-          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary transition-color ease-in-out duration-150'
+          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary transition-color ease-in-out duration-200'
       )}
     >
       <div className="bg-light-primary h-full w-fit flex-none px-6 py-4 dark:bg-dark lg:w-[290px]">

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -7,23 +7,13 @@ import { ThemeToggler } from '../ThemeToggler/themeToggler'
 import { TopBar } from '../TopBar/TopBar'
 import { SocialMediaIconsList } from 'components/SocialMedia/SocialMediaIconsList'
 import { useResults } from 'hooks/ResultsContext'
-import clsx from 'clsx'
-import { usePathname } from 'next/navigation'
 
 export const Header: FC = () => {
   const { toggleNav } = useContext(GlobalContext)
   const { results } = useResults()
-  const pathname = usePathname()
 
   return (
-    <header
-      className={clsx(
-        'fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary',
-
-        pathname != '/' &&
-          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary transition-color ease-in-out duration-200'
-      )}
-    >
+    <header className="fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary">
       <div className="bg-light-primary h-full w-fit flex-none px-6 py-4 dark:bg-dark lg:w-[290px]">
         <Link href="/" aria-label="LinksHub Logo">
           <Logo className="text-3xl" />

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export const Header: FC = () => {
         'fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary',
 
         pathname != '/' &&
-          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary lg:shadow-none transition-color ease-in-out duration-150'
+          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary transition-color ease-in-out duration-150'
       )}
     >
       <div className="bg-light-primary h-full w-fit flex-none px-6 py-4 dark:bg-dark lg:w-[290px]">

--- a/layouts/GeneralLayout.tsx
+++ b/layouts/GeneralLayout.tsx
@@ -8,9 +8,12 @@ import { SkipLink } from 'components/SkipLink/SkipLink'
 import { useContext } from 'react'
 import { IContext } from 'types'
 import { GlobalContext } from 'context/GlobalContext'
+import clsx from 'clsx'
+import { usePathname } from 'next/navigation'
 
 const GeneralLayout = ({ children }: { children: ReactNode }) => {
   const { sidebar } = useContext<IContext>(GlobalContext)
+  const pathname = usePathname()
 
   return (
     <>
@@ -26,7 +29,12 @@ const GeneralLayout = ({ children }: { children: ReactNode }) => {
           <Aside />
         </nav>
         <main
-          className="h-full px-4 lg:ml-[290px] lg:w-[calc(100%-290px)]"
+          className={clsx(
+            'h-full px-4 lg:ml-[290px] lg:w-[calc(100%-290px)]',
+
+            pathname != '/' &&
+              'lg:border-t lg:border-t-theme-primary lg:dark:border-t-theme-secondary transition-color ease-in-out duration-200'
+          )}
           id="main"
         >
           {children}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react": "18.0.31",
     "@types/react-dom": "18.0.11",
     "classnames": "^2.3.2",
+    "clsx": "^2.0.0",
     "copy-to-clipboard": "^3.3.3",
     "daisyui": "^2.51.5",
     "eslint": "8.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
+  clsx:
+    specifier: ^2.0.0
+    version: 2.0.0
   copy-to-clipboard:
     specifier: ^3.3.3
     version: 3.3.3
@@ -702,6 +705,11 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
     dev: false
 
   /color-convert@2.0.1:


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes (#1422)

## Changes proposed

I added a border to the bottom of the `Header.tsx` file for the visual distinction between top bar and cards if the route is anything other than "/".  I used the next/navigation `usePathname` to identify what the current path is.

I added the **clsx** dependency via _pnpm_ which allows for conditional statements within the className without having to use template literals.

```javascript
    <header
      className={clsx(
        'fixed top-0 left-0 z-30 row-start-1 row-end-2 flex h-[76px] w-screen items-center justify-between bg-light-primary dark:bg-dark border-b border-b-light-primary dark:border-b-dark-primary',

        pathname != '/' &&
          'lg:border-b lg:border-b-theme-primary lg:dark:border-b-theme-secondary transition-color ease-in-out duration-150'
      )}
    >
```

## Screenshots
![Screenshot 2023-08-30 at 10 56 29 AM](https://github.com/rupali-codes/LinksHub/assets/102450568/a9fe5ebc-8ac2-4f71-9f9e-3fe7655a5e65)

![Screenshot 2023-08-30 at 10 57 17 AM](https://github.com/rupali-codes/LinksHub/assets/102450568/7647543b-de3e-482a-b996-f9217fb5c401)

![Screenshot 2023-08-30 at 10 57 56 AM](https://github.com/rupali-codes/LinksHub/assets/102450568/badcb3fb-abc0-4954-9629-0139c4c9acb3)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->