### PR TITLE
chore: add workflow to check spam PRs in hacktoberfest

### DIFF
--- a/.github/workflows/spam_hacktoberfest.yml
+++ b/.github/workflows/spam_hacktoberfest.yml
@@ -1,0 +1,16 @@
+name: Hacktoberfest Spam PR Checker
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Spamtoberfest
+        uses: maximelafarie/spamtoberfest@main
+        with:
+          action-type: flag # or close
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> Reference: https://github.com/maximelafarie/spamtoberfest

> Can't find any other workflows.

## Fixes Issue

Closes #1702 

## Changes proposed

- I don't really how the workflow works, except that it will close the PR.
- Also, I don't think closing would be the right option, contributors can get a chance of correcting their mistakes.

## Note to reviewers

> Current option is `flag`, let me know if you want me to change it to `default`.

- There are two options as listed in the workflow:
   - `flag` - only adds a "Spam" label to the PR
   - `close` - adds a "Spam" label to the PR and closes it

- What does this means?

![image](https://github.com/rupali-codes/LinksHub/assets/74038190/d28f59e4-8047-4062-9e0b-3261de049949)
