### PR TITLE
chore: correct the layout of description icon of subcategories for hover state

### DIFF
--- a/components/TopBar/TopBar.tsx
+++ b/components/TopBar/TopBar.tsx
@@ -109,7 +109,7 @@ export const TopBar: FC<TopBarProps> = ({ className }) => {
                   data-tooltip-id="info-tooltip"
                   data-tooltip-content="Description"
                   data-tooltip-place="bottom"
-                  className="ml-4 mt-2 text-sm cursor-pointer hover:text-theme-primary"
+                  className="ml-4 mt-2 text-sm cursor-pointer hover:text-theme-primary outline-none"
                   onClick={handleCardClick}
                 />
               </button>

--- a/components/TopBar/TopBar.tsx
+++ b/components/TopBar/TopBar.tsx
@@ -71,12 +71,11 @@ export const TopBar: FC<TopBarProps> = ({ className }) => {
               <span className="flex uppercase text-gray-900 dark:text-gray-100">
                 {isSearchFound ? `${cleanedCategory}` : `No Results Found`}
               </span>
-              <button
-                data-tooltip-id="info-tooltip"
-                data-tooltip-content="Description"
-                data-tooltip-place="bottom"
-              >
+              <button>
                 <FaInfoCircle
+                  data-tooltip-id="info-tooltip"
+                  data-tooltip-content="Description"
+                  data-tooltip-place="bottom"
                   className="ml-4 mt-2 text-sm cursor-pointer hover:text-theme-primary"
                   onClick={handleCardClick}
                 />
@@ -105,12 +104,11 @@ export const TopBar: FC<TopBarProps> = ({ className }) => {
               <span className="flex uppercase text-gray-900 dark:text-gray-100">
                 {subcategoryName}
               </span>
-              <button
-                data-tooltip-id="info-tooltip"
-                data-tooltip-content="Description"
-                data-tooltip-place="bottom"
-              >
+              <button>
                 <FaInfoCircle
+                  data-tooltip-id="info-tooltip"
+                  data-tooltip-content="Description"
+                  data-tooltip-place="bottom"
                   className="ml-4 mt-2 text-sm cursor-pointer hover:text-theme-primary"
                   onClick={handleCardClick}
                 />


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes #1725 

## Changes proposed

the data-tooltip-id , data-tooltip-content, data-tooltip-place were shifted to the children Icon

## Screenshots
<img width="421" alt="Screenshot 2023-10-01 at 4 39 42 PM" src="https://github.com/rupali-codes/LinksHub/assets/78169683/7ac5dda3-8949-4504-a5be-e4a61e7816dd">