### PR TITLE
feat: add mandatory changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/---category-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/---category-suggestion.yml
@@ -1,50 +1,49 @@
-
-name: "Category Request ⚡"
-description: "Use this to add new category/subcategory into the Hub"
-title: "[ADD] <write the name of category/subcategory>"
-labels: ["chore", "goal: new-category"]
+name: 'Category Request ⚡'
+description: 'Use this to add new category/subcategory into the Hub'
+title: '[ADD] <write the name of category/subcategory>'
+labels: ['chore', 'goal: new-category', 'priority: low']
 
 body:
   - type: input
     id: concise_category
     attributes:
-      label: "Category Name"
+      label: 'Category Name'
       description: "If you are adding to an existing category, please write 'none'"
-      placeholder: "Enter the name of the category."
+      placeholder: 'Enter the name of the category.'
     validations:
       required: true
   - type: input
     id: concise_subcategory
     attributes:
-      label: "Subcategory Name"
-      description: "Please write the relevant subcategory that can be added for the category."
+      label: 'Subcategory Name'
+      description: 'Please write the relevant subcategory that can be added for the category.'
       placeholder: "For example 'images', 'fonts', 'colors', 'illustrations'"
     validations:
       required: true
   - type: textarea
     id: additional_context_category
     attributes:
-      label: "Additional Context"
-      description: "If you have any additional context or information that may help us understand the category/subcategory better, please provide it here"
-      placeholder: "You can write why this category should be included in the LinksHub."
+      label: 'Additional Context'
+      description: 'If you have any additional context or information that may help us understand the category/subcategory better, please provide it here'
+      placeholder: 'You can write why this category should be included in the LinksHub.'
     validations:
       required: false
   - type: checkboxes
     id: terms_checklist
     attributes:
-      label: "Checklist"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/rupali-codes/LinksHub/blob/main/CODE_OF_CONDUCT.md)"
+      label: 'Checklist'
+      description: 'By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/rupali-codes/LinksHub/blob/main/CODE_OF_CONDUCT.md)'
       options:
-        - label: "I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues?q=is%3Aissue+)"
+        - label: 'I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues?q=is%3Aissue+)'
           required: true
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I have checked that this category does not exist"
+        - label: 'I have checked that this category does not exist'
           required: false
-        - label: "I have checked that this subcategory does not exist"
+        - label: 'I have checked that this subcategory does not exist'
           required: true
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
   - type: markdown
     attributes:
-      value: "Thank you for taking the time to suggest a new request! Your input is greatly appreciated."
+      value: 'Thank you for taking the time to suggest a new request! Your input is greatly appreciated.'

--- a/.github/ISSUE_TEMPLATE/add_link.yml
+++ b/.github/ISSUE_TEMPLATE/add_link.yml
@@ -1,7 +1,7 @@
 name: New Link 🔗
 description: Use this to add new link into the Hub
 title: '[Add] <write what you want to add>'
-labels: ['chore', 'goal: new-link']
+labels: ['chore', 'goal: new-link', 'priority: low']
 body:
   - type: input
     attributes:
@@ -52,4 +52,3 @@ body:
 
         - label: 'I am willing to work on this issue (optional)'
           required: false
-

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,51 +1,49 @@
 name: ​🐞 Bug
 description: Report an issue to help us improve the project.
-title: "[BUG] <write a small description here>"
-labels: ["bug", "goal: fix"]
+title: '[BUG] <write a small description here>'
+labels: ['bug', 'goal: fix', 'priority: medium']
 body:
   - type: textarea
-    attributes:  
-      label: Description   
-      id: description  
+    attributes:
+      label: Description
+      id: description
       description: A brief description of the issue or bug you are facing, also include what you tried and what didn't work.
     validations:
       required: false
   - type: textarea
-    attributes: 
+    attributes:
       label: Screenshots
       id: screenshots
       description: Please add screenshots if applicable
     validations:
       required: false
   - type: textarea
-    attributes: 
-      label: Any additional information? 
+    attributes:
+      label: Any additional information?
       id: extrainfo
-      description: Any additional information or Is there anything we should know about this bug? 
-    validations: 
+      description: Any additional information or Is there anything we should know about this bug?
+    validations:
       required: false
   - type: dropdown
     id: browsers
-    attributes: 
-      label: What browser are you seeing the problem on? 
+    attributes:
+      label: What browser are you seeing the problem on?
       multiple: true
-      options: 
+      options:
         - Firefox
         - Chrome
         - Safari
-        - Microsoft Edge      
+        - Microsoft Edge
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-        
-                 

--- a/.github/ISSUE_TEMPLATE/category_description.yml
+++ b/.github/ISSUE_TEMPLATE/category_description.yml
@@ -1,8 +1,8 @@
 name: Category Description 📝
 description: Use this to add or update the category's description
-title: "[Description] <write which description you want to add or update>"
-labels: ["chore", "goal: description"]
-body: 
+title: '[Description] <write which description you want to add or update>'
+labels: ['chore', 'goal: description', 'priority: low']
+body:
   - type: input
     attributes:
       label: Category Name
@@ -24,23 +24,21 @@ body:
     attributes:
       label: Status of Description
       options:
-        - label: "Adding new description"
+        - label: 'Adding new description'
           required: false
 
-        - label: "Updating existing description"
+        - label: 'Updating existing description'
           required: false
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-        
-        

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request 💡
 description: Have any new idea or new feature for LinksHub? Please suggest!
-title: "[Feature] <write a small description here>"
-labels: ["enhancement", "goal: addition"]
+title: '[Feature] <write a small description here>'
+labels: ['enhancement', 'goal: addition', 'priority: high']
 body:
   - type: textarea
     id: description
@@ -20,14 +20,13 @@ body:
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-

--- a/.github/ISSUE_TEMPLATE/refactor_code.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_code.yml
@@ -1,7 +1,7 @@
 name: Refactor Code 🔧
 description: Use this label for code refactoring tasks.
 title: '[Refactor] <write what you want to add>'
-labels: ['goal: refactor']
+labels: ['goal: refactor', 'priority: medium']
 body:
   - type: input
     attributes:
@@ -33,4 +33,3 @@ body:
 
         - label: 'I am willing to work on this issue (optional).'
           required: false
-

--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -6,6 +6,13 @@ filters:
     events: [pull_request]
     targets: [title]
 
+  - label: 'priority: high'
+    regexs:
+      - /\bfeat\b/
+      - /feature/i
+    events: [pull_request]
+    targets: [title]
+
   - label: 'documentation'
     regexs:
       - /docs/i
@@ -22,6 +29,16 @@ filters:
       - /fix/i
     events: [pull_request]
     targets: [title]
+  - label: 'priority: medium'
+    regexs:
+      - /bug/i
+    events: [pull_request]
+    targets: [title]
+  - label: 'priority: medium'
+    regexs:
+      - /fix/i
+    events: [pull_request]
+    targets: [title]
 
   - label: 'chore'
     regexs:
@@ -29,6 +46,11 @@ filters:
     events: [pull_request]
     targets: [title]
   - label: 'goal: new-category'
+    regexs:
+      - /category/i
+    events: [pull_request]
+    targets: [title]
+  - label: 'priority: low'
     regexs:
       - /category/i
     events: [pull_request]
@@ -46,14 +68,30 @@ filters:
       - /link/i
     events: [pull_request]
     targets: [title]
+  - label: 'priority: low'
+    regexs:
+      - /\blink\b/
+      - /link/i
+    events: [pull_request]
+    targets: [title]
 
   - label: 'chore'
     regexs:
       - /description/i
     events: [pull_request]
     targets: [title]
+  - label: 'priority: low'
+    regexs:
+      - /description/i
+    events: [pull_request]
+    targets: [title]
 
   - label: 'chore'
+    regexs:
+      - /chore/i
+    events: [pull_request]
+    targets: [title]
+  - label: 'priority: low'
     regexs:
       - /chore/i
     events: [pull_request]
@@ -71,6 +109,12 @@ filters:
       - /refactor/i
     events: [pull_request]
     targets: [title]
+  - label: 'priority: medium'
+    regexs:
+      - /\brefactor\b/
+      - /refactor/i
+    events: [pull_request]
+    targets: [title]
 
   - label: 'accessibility'
     regexs:
@@ -78,3 +122,9 @@ filters:
       - /accessibility/i
     events: [issues, pull_request] # default
     targets: [title, comment] # default
+  - label: 'priority: medium'
+    regexs:
+      - /\baccessibility\b/
+      - /accessibility/i
+    events: [issues, pull_request] # default
+    targets: [title, comment]

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: EddieHubCommunity/gh-action-community/src/welcome@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Hello ${{ github.actor }}! \n Thank you for raising this issue! 😊 Your contribution is valuable to us! 😊 \n\nPlease make sure to follow our [Contributing Guidelines. 💪🏻](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md) \n\nOur review team will carefully assess the issue and reach out to you soon! 😇 \n We appreciate your patience! "
+          issue-message: "Hello ${{ github.actor }}! \n Thank you for raising this issue! 😊 Your contribution is valuable to us! 😊 \n\nPlease make sure to follow our [Contributing Guidelines. 💪🏻](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md) \n\nPlease only work on an issue if you're assigned; otherwise, the PR will be automatically closed.\nOur review team will carefully assess the issue and reach out to you soon! 😇 \n We appreciate your patience! "
           pr-message: "Thank you, ${{ github.actor }}, for creating this pull request and contributing to LinksHub! 💗\n\n The maintainers will review this Pull Request and provide feedback as soon as possible! 😇\nWe appreciate your patience and contribution, Keep up the great work! 😀"

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -66,7 +66,7 @@ const ContributorsPage: FC<{ contributors: Contributor[] }> = ({
   const [hoveredContributor, setHoveredContributor] = useState<string>('')
   const { resolvedTheme } = useTheme()
   const filteredContributors = contributors.filter(
-    (contributor) => contributor.contributions >= 6
+    (contributor) => contributor.contributions >= 1
   )
 
   const sortedContributors = filteredContributors.sort(


### PR DESCRIPTION
## Fixes Issue

Closes #1730 
Closes #1727 

## Changes proposed

- Already mentioned in the Issue description

## Note to reviewers

@rupali-codes @CBID2 
I need to implement these,

> Can you suggest something.
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/b8c6efde-4696-473f-a0f5-96b8a5b03240)

I found this workflow out of several others: https://github.com/nearform-actions/github-action-check-linked-issues, but I don't understand what it does after finding the linked issues count.

So, maybe we have to sync three workflows, one to find linked issues, then close a pr and then add a comment on the PR.