### PR TITLE
Fix searchbar query persist even after clearing the searchbar

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -33,6 +33,12 @@ export const Searchbar: React.FC<SearchbarProps> = ({
       type: 'search_query_change',
       searchQuery: e.target.value,
     })
+    
+    if(!e.target.value && router.asPath!="/" && router.asPath.substring(1,7)=="search" ){
+      searchQuery=""
+      
+      router.push("/")
+    }
   }
 
   const handleSuggestionClick = (searchQuery: string) => {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes Issue #1518 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
When searchbar is cleared it go back to the home page if  the url contain a query tag or it will remain on the same page if a query tag isn't present
<!-- List all the proposed changes in your PR -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

https://github.com/rupali-codes/LinksHub/assets/65841021/6c58e7ea-fce5-4d0b-9617-281400662d11


## Note to reviewers

<!-- Add notes to reviewers if applicable -->