### PR TITLE
chore: add option to check participation in hacktoberfest

### DIFF
--- a/.github/ISSUE_TEMPLATE/---category-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/---category-suggestion.yml
@@ -1,50 +1,51 @@
-
-name: "Category Request ⚡"
-description: "Use this to add new category/subcategory into the Hub"
-title: "[ADD] <write the name of category/subcategory>"
-labels: ["chore", "goal: new-category"]
+name: 'Category Request ⚡'
+description: 'Use this to add new category/subcategory into the Hub'
+title: '[ADD] <write the name of category/subcategory>'
+labels: ['chore', 'goal: new-category']
 
 body:
   - type: input
     id: concise_category
     attributes:
-      label: "Category Name"
+      label: 'Category Name'
       description: "If you are adding to an existing category, please write 'none'"
-      placeholder: "Enter the name of the category."
+      placeholder: 'Enter the name of the category.'
     validations:
       required: true
   - type: input
     id: concise_subcategory
     attributes:
-      label: "Subcategory Name"
-      description: "Please write the relevant subcategory that can be added for the category."
+      label: 'Subcategory Name'
+      description: 'Please write the relevant subcategory that can be added for the category.'
       placeholder: "For example 'images', 'fonts', 'colors', 'illustrations'"
     validations:
       required: true
   - type: textarea
     id: additional_context_category
     attributes:
-      label: "Additional Context"
-      description: "If you have any additional context or information that may help us understand the category/subcategory better, please provide it here"
-      placeholder: "You can write why this category should be included in the LinksHub."
+      label: 'Additional Context'
+      description: 'If you have any additional context or information that may help us understand the category/subcategory better, please provide it here'
+      placeholder: 'You can write why this category should be included in the LinksHub.'
     validations:
       required: false
   - type: checkboxes
     id: terms_checklist
     attributes:
-      label: "Checklist"
-      description: "By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/rupali-codes/LinksHub/blob/main/CODE_OF_CONDUCT.md)"
+      label: 'Checklist'
+      description: 'By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/rupali-codes/LinksHub/blob/main/CODE_OF_CONDUCT.md)'
       options:
-        - label: "I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues?q=is%3Aissue+)"
+        - label: 'I have checked the existing [issues](https://github.com/rupali-codes/LinksHub/issues?q=is%3Aissue+)'
           required: true
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I have checked that this category does not exist"
+        - label: 'I have checked that this category does not exist'
           required: false
-        - label: "I have checked that this subcategory does not exist"
+        - label: 'I have checked that this subcategory does not exist'
           required: true
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
+          required: false
+        - label: 'I am participating in Hacktoberfest 2023'
           required: false
   - type: markdown
     attributes:
-      value: "Thank you for taking the time to suggest a new request! Your input is greatly appreciated."
+      value: 'Thank you for taking the time to suggest a new request! Your input is greatly appreciated.'

--- a/.github/ISSUE_TEMPLATE/add_link.yml
+++ b/.github/ISSUE_TEMPLATE/add_link.yml
@@ -53,3 +53,5 @@ body:
         - label: 'I am willing to work on this issue (optional)'
           required: false
 
+        - label: 'I am participating in Hacktoberfest 2023'
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,51 +1,52 @@
 name: ​🐞 Bug
 description: Report an issue to help us improve the project.
-title: "[BUG] <write a small description here>"
-labels: ["bug", "goal: fix"]
+title: '[BUG] <write a small description here>'
+labels: ['bug', 'goal: fix']
 body:
   - type: textarea
-    attributes:  
-      label: Description   
-      id: description  
+    attributes:
+      label: Description
+      id: description
       description: A brief description of the issue or bug you are facing, also include what you tried and what didn't work.
     validations:
       required: false
   - type: textarea
-    attributes: 
+    attributes:
       label: Screenshots
       id: screenshots
       description: Please add screenshots if applicable
     validations:
       required: false
   - type: textarea
-    attributes: 
-      label: Any additional information? 
+    attributes:
+      label: Any additional information?
       id: extrainfo
-      description: Any additional information or Is there anything we should know about this bug? 
-    validations: 
+      description: Any additional information or Is there anything we should know about this bug?
+    validations:
       required: false
   - type: dropdown
     id: browsers
-    attributes: 
-      label: What browser are you seeing the problem on? 
+    attributes:
+      label: What browser are you seeing the problem on?
       multiple: true
-      options: 
+      options:
         - Firefox
         - Chrome
         - Safari
-        - Microsoft Edge      
+        - Microsoft Edge
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-        
-                 
+
+        - label: 'I am participating in Hacktoberfest 2023'
+          required: false

--- a/.github/ISSUE_TEMPLATE/category_description.yml
+++ b/.github/ISSUE_TEMPLATE/category_description.yml
@@ -1,8 +1,8 @@
 name: Category Description 📝
 description: Use this to add or update the category's description
-title: "[Description] <write which description you want to add or update>"
-labels: ["chore", "goal: description"]
-body: 
+title: '[Description] <write which description you want to add or update>'
+labels: ['chore', 'goal: description']
+body:
   - type: input
     attributes:
       label: Category Name
@@ -24,23 +24,24 @@ body:
     attributes:
       label: Status of Description
       options:
-        - label: "Adding new description"
+        - label: 'Adding new description'
           required: false
 
-        - label: "Updating existing description"
+        - label: 'Updating existing description'
           required: false
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-        
-        
+
+        - label: 'I am participating in Hacktoberfest 2023'
+          required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -11,11 +11,6 @@ body:
       description: 'Please provide a brief summary of the documentation issue you are experiencing or would like to address.'
     validations:
       required: true
-  - type: textarea
-    id: additional_context_docs
-    attributes:
-      label: 'Additional Context'
-      description: 'If there is any additional context or information that would be helpful for addressing the documentation issue, please provide it here.'
 
   - type: textarea
     id: screenshots_examples_docs
@@ -40,6 +35,8 @@ body:
         - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
         - label: 'I am willing to work on this issue (optional)'
+          required: false
+        - label: 'I am participating in Hacktoberfest 2023'
           required: false
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request 💡
 description: Have any new idea or new feature for LinksHub? Please suggest!
-title: "[Feature] <write a small description here>"
-labels: ["enhancement", "goal: addition"]
+title: '[Feature] <write a small description here>'
+labels: ['enhancement', 'goal: addition']
 body:
   - type: textarea
     id: description
@@ -20,14 +20,16 @@ body:
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
 
+        - label: 'I am participating in Hacktoberfest 2023'
+          required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,27 +1,25 @@
-name: Other 
+name: Other
 description: Use this for any other question or issue. Please do not create blank issues
-title: "[OTHER]"
-labels: ["status: awaiting triage"]
-body: 
+title: '[OTHER]'
+labels: ['status: awaiting triage']
+body:
   - type: textarea
     id: issuedescription
-    attributes: 
-      label: What would you like to share or ask? 
+    attributes:
+      label: What would you like to share or ask?
       description: Provide a clear and concise explanation of your issue.
-    validations: 
+    validations:
       required: true
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "Checklist"
+      label: 'Checklist'
       options:
-        - label: "I have checked the existing issues"
+        - label: 'I have checked the existing issues'
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: 'I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)'
           required: true
 
-        - label: "I am willing to work on this issue (optional)"
+        - label: 'I am willing to work on this issue (optional)'
           required: false
-        
-        

--- a/.github/ISSUE_TEMPLATE/refactor_code.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_code.yml
@@ -34,3 +34,5 @@ body:
         - label: 'I am willing to work on this issue (optional).'
           required: false
 
+        - label: 'I am participating in Hacktoberfest 2023'
+          required: false


### PR DESCRIPTION
## Fixes Issue

Resolves #1744 

## Changes proposed

- Add this option in all issue forms (except `Other`)
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/272322b4-b41d-433c-a850-33bdac321e51)

- Remove additional context from documentation issue form
![image](https://github.com/rupali-codes/LinksHub/assets/74038190/dfe6573d-8096-45a0-ac30-02dbbd32dd47)

The issue form is very long, and to make it very concise like other issue forms in the repo. It is better to remove extra sections.

## Note to reviewers

@CBID2 @rupali-codes 
Review this.