### PR TITLE
feat: Improve search bar suggestions

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -4,9 +4,10 @@ import SearchIcon from 'assets/icons/SearchIcon'
 import { SearchbarSuggestions } from './SearchbarSuggestions'
 import { ErrorMessage } from 'components/ErrorMessage'
 
-import { subcategoryArray } from '../../types'
+import { SubCategories, subcategoryArray } from '../../types'
 import { SearchbarAction } from './SearchbarReducer'
 import { useRouter } from 'next/router'
+import { sidebarData } from 'database/data'
 
 interface SearchbarProps {
   dispatchSearch: (action: SearchbarAction) => void
@@ -35,14 +36,14 @@ export const Searchbar: React.FC<SearchbarProps> = ({
     })
   }
 
-  const handleSuggestionClick = (searchQuery: string) => {
-    dispatchSearch({ type: 'suggestion_click', searchQuery })
-    router.push({
-      pathname: '/search',
-      query: {
-        query: searchQuery,
-      },
-    })
+  const handleSuggestionClick = (searchQuery: SubCategories) => {
+    console.log(searchQuery)
+    dispatchSearch({ type: 'suggestion_click', searchQuery: searchQuery.name })
+    const { category } = sidebarData.find((item) =>
+      item.subcategory.some((subCat) => subCat.name === searchQuery.name)
+    ) || { category: '' }
+
+    router.push(`/${category}${searchQuery.url}`)
   }
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -117,13 +118,9 @@ const getFilteredSuggestions = (query: string) => {
     return []
   }
 
-  const suggestions = new Set<string>([])
-  searchOptions.forEach((option) => {
-    const normalisedOption = option.toLowerCase()
-    if (normalisedOption.includes(normalisedQuery)) {
-      suggestions.add(normalisedOption)
-    }
-  })
+  const suggestions = searchOptions.filter((option) =>
+    option.name.toLowerCase().includes(normalisedQuery)
+  )
 
-  return Array.from(suggestions)
+  return suggestions
 }

--- a/components/Searchbar/SearchbarSuggestions.tsx
+++ b/components/Searchbar/SearchbarSuggestions.tsx
@@ -1,6 +1,8 @@
+import { SubCategories } from 'types'
+
 interface SuggestionsProps {
-  suggestions: string[]
-  onSuggestionClick: (suggestion: string) => void
+  suggestions: SubCategories[]
+  onSuggestionClick: (suggestion: SubCategories) => void
 }
 
 export const SearchbarSuggestions: React.FC<SuggestionsProps> = ({
@@ -11,11 +13,11 @@ export const SearchbarSuggestions: React.FC<SuggestionsProps> = ({
     <ul className="absolute z-10 text-light-primary bg-theme-secondary w-full mt-1 rounded-lg shadow-2xl">
       {suggestions.map((suggestion) => (
         <li
-          key={suggestion}
+          key={suggestion.url}
           className="px-4 py-2 cursor-pointer hover:bg-[rgba(0,0,0,0.2)] capitalize"
           onClick={() => onSuggestionClick(suggestion)}
         >
-          {suggestion.replace('-', ' ')}
+          {suggestion.name}
         </li>
       ))}
     </ul>

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,5 @@
+import { sidebarData } from 'database/data'
+
 export type DataList = {
   name: string
   description: string
@@ -69,98 +71,6 @@ export interface IContext {
   toggleNav?: () => void
 }
 
-export const subcategoryArray = [
-  // devops
-  'cicd',
-  'devops-life-cycle',
-  'devops-methodologies',
-  'docker',
-  'kubernetes',
-  'microservices',
-  //frontend
-  'accessibility',
-  'animations',
-  'colors',
-  'design-inspiration',
-  'fonts',
-  'icons',
-  'illustrations',
-  'images',
-  'online-code-editors',
-  'react',
-  'next-js',
-  'three-js',
-  'themes-templates',
-  'ui-generators',
-  //backend
-  'architecture',
-  'authentication',
-  'caching',
-  'database',
-  'security',
-  'system-design',
-  'testing',
-  'validation',
-  // languages
-  'c-programming',
-  'csharp',
-  'golang',
-  'java',
-  'javascript',
-  'kotlin',
-  'python',
-  'ruby',
-  'typescript',
-  //artificial intelligence
-  'artificial-intelligence',
-  //Internet of Things
-  'coursera',
-  'Esp-32',
-  'Sensors',
-  'Raspberry pi',
-  //cloud computing
-  'google cloud',
-  'aws',
-  'azure',
-  'oracle',
-  'ibm',
-  // machin learning
-  'data-science',
-  'deep-learning',
-  'machine-learning',
-  // Open-source
-  'articles',
-  'projects',
-  'tools',
-  'os-tutorials',
-  // resources
-  'blogs',
-  'e-book',
-  'hosting',
-  'officialdocs',
-  'project-ideas',
-  // youtube
-  'android',
-  'cp-platforms',
-  'cp-tutorials',
-  'css',
-  'data-structures',
-  'fintech',
-  'game-development',
-  'machine-learning',
-  'tensorflow',
-  'software-testing',
-  'web-development',
-  'web3-metaverse',
-  // other
-  'communities',
-  'devtools',
-  'github',
-  'other-resources',
-  'podcasts',
-  'roadmaps',
-  // competitive programming
-  'platforms',
-  // technical-writing
-  'technical-writing-tools',
-]
+export const subcategoryArray = sidebarData
+  .map((item) => item.subcategory.flat())
+  .flat()


### PR DESCRIPTION
All subcategory are now displayed in the search bar suggestions. Also, we don't need to keep two lists of subcategories in different places anymore.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #1746 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

## Screenshots

https://github.com/rupali-codes/LinksHub/assets/70102539/9840c747-5b05-4063-917c-b43533dae88c



<!-- Add all the screenshots which support your changes -->

## Note to reviewers
I had a hard time deciding if I should open this PR. While the commit message doesn't relate to the issue, I found out this is the solution while working on the issue. If you check the subcategories we have, you'll notice that some subcategories have `&` like `Themes & Template` while some have `/` like `CI/CD`. We even have `C#`😅.

So to avoid having a series of `if` statements while providing:
- complete suggestions
- correct URL

I thought it's better we derive the suggestions from the actual list([sidebarData](https://github.com/rupali-codes/LinksHub/blob/main/database/data.ts#L9)) we have. 

This helps:
- to maintain one list
- no need to think about what the URL should look like since we will be getting the URL from the suggestion itself.

<!-- Add notes to reviewers if applicable -->