### PR TITLE
cp tutorial page fix

### DIFF
--- a/database/competitive_programming/cp-tutorials.json
+++ b/database/competitive_programming/cp-tutorials.json
@@ -2,7 +2,7 @@
   {
     "name": "Errichto",
     "description": "This channel provides competitive programming tactics, problem-solving techniques, and thought processes behind advanced algorithms.",
-    "url": "https://www.competitive-programming.com/@Errichto",
+    "url": "https://www.youtube.com/@Errichto",
     "category": "competitive-programming",
     "subcategory": "cp-tutorials",
     "language": "english"
@@ -10,7 +10,7 @@
   {
     "name": "Luv",
     "description": "This channel offers a wealth of videos focused on enhancing coding skills and excelling in competitive programming challenges.",
-    "url": "https://www.competitive-programming.com/watch?v=OMcxQ3IY-qc&list=PLauivoElc3ggagradg8MfOZreCMmXMmJ-",
+    "url": "https://www.youtube.com/@iamluv",
     "category": "competitive-programming",
     "subcategory": "cp-tutorials",
     "language": "english"
@@ -18,7 +18,7 @@
   {
     "name": "Priyansh Agarwal",
     "description": "This channel provides insightful content on competitive programming topics and solutions for Codeforces, LeetCode, and CodeChef coding contests.",
-    "url": "https://www.competitive-programming.com/c/PriyanshAgarwal",
+    "url": "https://www.youtube.com/@PriyanshAgarwal",
     "category": "competitive-programming",
     "subcategory": "cp-tutorials",
     "language": "english"
@@ -26,7 +26,7 @@
   {
     "name": "Utkarsh Gupta",
     "description": "This channel provides in-depth tutorials, insightful strategies, and expert solutions to coding challenges from platforms like LeetCode, Codeforces, and CodeChef, empowering your competitive programming journey.",
-    "url": "https://www.competitive-programming.com/channel/UCGS5ZzcSAymQbWZvNoKOFhQ",
+    "url": "https://www.youtube.com/@utkarshgupta9858",
     "category": "competitive-programming",
     "subcategory": "cp-tutorials",
     "language": "english"


### PR DESCRIPTION
#1843 

closes #1843

## Changes proposed

I have changed the sources in competitive programming tutorial page. In database->competitive-programming->cp-tutorials

## Screenshots

![image](https://github.com/rupali-codes/LinksHub/assets/97040203/9be7c0e4-a5fc-4aaf-89c6-f3979f631eb3)


![image](https://github.com/rupali-codes/LinksHub/assets/97040203/48b10771-f873-47cb-aab7-666ddccb931c)

