### PR TITLE
added emailProviders as subcategory in backend

### DIFF
--- a/database/backend/email-providers.json
+++ b/database/backend/email-providers.json
@@ -1,0 +1,37 @@
+[
+    {
+        "name": "EmailJS",
+        "description": "EmailJS is a platform that simplifies sending emails through JavaScript by providing an API for seamless integration with web applications.",
+        "url": "https://www.emailjs.com/",
+        "category": "backend",
+        "subcategory": "email-providers"  
+    },
+    {
+        "name": "Nodemailer",
+        "description": "Nodemailer is a JavaScript library for sending emails from Node.js applications with ease and flexibility.",
+        "url": "https://nodemailer.com/",
+        "category": "backend",
+        "subcategory": "email-providers"  
+    },
+    {
+        "name": "Mailgun",
+        "description": "Mailgun is a powerful email delivery service designed for developers, offering robust APIs and tools to send, receive, and track emails effortlessly.",
+        "url": "https://www.mailgun.com/",
+        "category": "backend",
+        "subcategory": "email-providers"  
+    },
+    {
+        "name": "SendGrid",
+        "description": "SendGrid is a cloud-based email delivery platform trusted by developers for its scalability and comprehensive API solutions.",
+        "url": "https://sendgrid.com/",
+        "category": "backend",
+        "subcategory": "email-providers"  
+    },
+    {
+        "name": "Amazon SES",
+        "description": "Amazon SES is an email tool that also supports a variety of deployments including dedicated, shared, or owned IP addresses. ",
+        "url": "https://aws.amazon.com/ses/",
+        "category": "backend",
+        "subcategory": "email-providers"  
+    }
+]

--- a/database/data.ts
+++ b/database/data.ts
@@ -63,6 +63,11 @@ export const sidebarData: ISidebar[] = [
         url: '/authentication',
         resources: DB.authentication,
       },
+      {
+        name: 'email providers',
+        url: '/email-providers',
+        resources: DB.emailProviders,
+      },
       { name: 'caching', url: '/caching', resources: DB.caching },
       { name: 'testing', url: '/testing', resources: DB.testing },
       {

--- a/database/index.ts
+++ b/database/index.ts
@@ -23,6 +23,7 @@ export { default as validation } from './backend/validation.json'
 export { default as systemDesign } from './backend/system-design.json'
 export { default as database } from './backend/database.json'
 export { default as api } from './backend/api.json'
+export { default as emailProviders } from './backend/email-providers.json'
 
 //devops
 export { default as cicd } from './devops/cicd.json'


### PR DESCRIPTION

## Fixes Issue

closes #1860

## Changes proposed

a) Added "Email Providers" as a new subcategory in the backend section.
b) Included links to popular email service providers like Nodemailer and SendGrid within the "Email Providers" subcategory.
c) Updated the navigation menu to include a link to the new "Email Providers" subcategory.
d) Ensured that the subcategory is organized and styled consistently with the rest of the website.
e) Tested the functionality of the new subcategory to ensure smooth user experience.

## Screenshots
![emailpr](https://github.com/rupali-codes/LinksHub/assets/145835714/d9c3334f-6074-4995-b0e5-763c52bd0647)


