### PR TITLE
adding FreeFrontend and IconScout to themes and illustration respectively

### DIFF
--- a/database/frontend/illustrations.json
+++ b/database/frontend/illustrations.json
@@ -117,5 +117,12 @@
     "url": "https://www.pixeltrue.com/free-illustrations",
     "category": "frontend",
     "subcategory": "illustrations"
+  },
+  {
+    "name": "IconScout",
+    "description": "Get millions of 3Ds, icons, illustrations, Lottie animations, and best-in-class search tools for your website, mobile app or project with the IconScout API.",
+    "url": "https://iconscout.com/",
+    "category": "frontend",
+    "subcategory": "illustrations"
   }
 ]

--- a/database/frontend/themes-templates.json
+++ b/database/frontend/themes-templates.json
@@ -47,5 +47,12 @@
     "url": "https://create.vista.com/",
     "category": "frontend",
     "subcategory": "themes-templates"
+  },
+  {
+    "name": "FreeFrontend",
+    "description": "It is a free and open-source collection of high-quality, responsive, and accessible front-end components and templates. It is a great resource for designers and developers who want to create beautiful and user-friendly websites and applications.",
+    "url": "https://freefrontend.com/",
+    "category": "frontend",
+    "subcategory": "themes-templates"
   }
 ]


### PR DESCRIPTION

## Fixes Issue

Closes #1879

## Changes proposed

a) Added links to FreeFrontend  "Themes and Templates" and  subcategory of the frontend.
b) Added links to IconScout  "Illustration" and  subcategory of the frontend.
b) Updated the subcategory's content to include brief descriptions of FreeFrontend and Illustration.
c) Ensured that the new links are well-formatted and functional.
d) Organized the subcategory to maintain consistency with existing resources.
e) Verified that the links accurately direct users to the relevant Postman and Cypress resources.

## Screenshots
<img width="1439" alt="Screenshot 2023-10-07 at 6 15 58 PM" src="https://github.com/rupali-codes/LinksHub/assets/145835714/96d35191-4214-4193-9cb2-10482ddab532">

<img width="1439" alt="Screenshot 2023-10-07 at 6 16 35 PM" src="https://github.com/rupali-codes/LinksHub/assets/145835714/17ecfe2a-c45e-4b2e-89ae-e1ea9b35c9c1">
