### PR TITLE
feat: add icons next to the "Visit Site" button to signify the destination type

### DIFF
--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -1,5 +1,6 @@
 import { FC, useState, useRef, useEffect } from 'react'
-import { BsBoxArrowUpRight } from 'react-icons/bs'
+import {BsYoutube } from 'react-icons/bs'
+import{MdArticle} from 'react-icons/md'
 import { CopyToClipboard } from 'components/CopyToClipboard/CopyToClipboard'
 import Share from 'components/Share/Share'
 import type { IData } from 'types'
@@ -12,6 +13,7 @@ export const Card: FC<CardProps> = ({ data }) => {
   const { name, description, url } = data
   const descriptionRef = useRef<HTMLParagraphElement>(null)
   const [isOverflow, setIsOverflow] = useState(false)
+  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/
 
   useEffect(() => {
     if (descriptionRef.current) {
@@ -63,7 +65,7 @@ export const Card: FC<CardProps> = ({ data }) => {
             }
           >
             Visit site
-            <BsBoxArrowUpRight />
+            {youtubeRegex.test(url) ? <BsYoutube size="1.5em"/> : <MdArticle size="1.5em"/>}
           </a>
         </footer>
       </div>

--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -1,5 +1,6 @@
 import { FC, useState, useRef, useEffect } from 'react'
-import {BsYoutube } from 'react-icons/bs'
+import {BsYoutube , BsPen} from 'react-icons/bs'
+import {AiOutlineRead} from 'react-icons/ai'
 import{MdArticle} from 'react-icons/md'
 import { CopyToClipboard } from 'components/CopyToClipboard/CopyToClipboard'
 import Share from 'components/Share/Share'
@@ -10,7 +11,7 @@ interface CardProps {
 }
 
 export const Card: FC<CardProps> = ({ data }) => {
-  const { name, description, url } = data
+  const { name, description, url,subcategory } = data
   const descriptionRef = useRef<HTMLParagraphElement>(null)
   const [isOverflow, setIsOverflow] = useState(false)
   const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/
@@ -65,7 +66,7 @@ export const Card: FC<CardProps> = ({ data }) => {
             }
           >
             Visit site
-            {youtubeRegex.test(url) ? <BsYoutube size="1.5em"/> : <MdArticle size="1.5em"/>}
+            {youtubeRegex.test(url) ? <BsYoutube size="1.3em"/> : subcategory==='e-book'?<AiOutlineRead size="1.3em"/>:subcategory==='technical-writing-tools'?<BsPen size="1.2em"/>:<MdArticle size="1.3em"/>}
           </a>
         </footer>
       </div>

--- a/components/popup/popupInfo.tsx
+++ b/components/popup/popupInfo.tsx
@@ -5,6 +5,9 @@ import { Backdrop } from 'components/Backdrop/Backdrop'
 import { createPortal } from 'react-dom'
 import useDelayUnmount from 'hooks/useDelayUnmount'
 import { CopyToClipboard } from 'components/CopyToClipboard/CopyToClipboard'
+import {BsYoutube,BsPen } from 'react-icons/bs'
+import{MdArticle} from 'react-icons/md'
+import {AiOutlineRead} from 'react-icons/ai'
 
 export const PopupInfo: React.FC<{
   currentCard: IData | null
@@ -21,6 +24,8 @@ export const PopupInfo: React.FC<{
   if (!overlayRoot) {
     return null
   }
+
+  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/
 
   return (
     <>
@@ -62,9 +67,10 @@ export const PopupInfo: React.FC<{
               href={currentCard?.url}
               target="_blank"
               rel="noreferrer"
-              className="mt-2 px-6 py-2 text-white text-center bg-theme-secondary rounded-2xl w-full hover:bg-transparent hover:text-theme-secondary border border-dashed border-transparent duration-100 hover:border-theme-primary flex items-center justify-center bottom-0 relative"
+              className="mt-2 px-6 py-2 text-white text-center bg-theme-secondary rounded-2xl w-full hover:bg-transparent hover:text-theme-secondary border border-dashed border-transparent duration-100 hover:border-theme-primary flex items-center justify-center bottom-0 relative gap-2"
             >
-              Visit site
+              Visit Site 
+              {youtubeRegex.test(currentCard?.url||'') ? <BsYoutube size="1.3em"/> : currentCard?.subcategory==='e-book'?<AiOutlineRead size="1.3em"/>:currentCard?.subcategory==='technical-writing-tools'?<BsPen size="1.2em"/>:<MdArticle size="1.3em"/>}
             </a>
           </div>
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

This PR closes issue #1926 
Closes #1982

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

Added small icons next to the "Visit Site" button to signify the destination type:
- Display a YouTube logo icon if the link redirects to YouTube (for users who prefer video tutorials).
- Show a "document" icon if the link redirects to an article, blog, or documentation website (for users who prefer reading). 

## Files Modified

- `components/Cards/Card.tsx`

## Screenshots

<!-- Add all the screenshots which support your changes -->
### Before this PR
![LinksHub-Languages-c-programming](https://github.com/rupali-codes/LinksHub/assets/130365071/d64971be-7384-4d82-88b9-16e67e72b10d)

### After this PR
[LinksHub.webm](https://github.com/rupali-codes/LinksHub/assets/130365071/743a10cd-8135-48e8-b11b-814a2a28075d)


## Note to reviewers

@rupali-codes , @Anmol-Baranwal , @CBID2 please review this PR.
Thanks