### PR TITLE
Fix Issue #1955: Removed Icon Liberary(Font Awesome) Link from Font c…

### DIFF
--- a/database/frontend/fonts.json
+++ b/database/frontend/fonts.json
@@ -1,86 +1,80 @@
 [
-    {
-        "name": "Google Fonts",
-        "description": "The No. 1 resource for free and easy-to-use webfonts by Google. It has a huge library of fonts. ",
-        "url": "https://fonts.google.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Fonts Quirrel",
-        "description": "Fonts Quirrel is platform to get free commercial fonts for your project. It's another huge library for fonts ",
-        "url": "https://fontsquirrel.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "1001 fonts",
-        "description": "1001 fonts is a platform that offers 42933 free fonts in 24214 families · Free licenses for commercial use·",
-        "url": "https://www.1001fonts.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Font Joy",
-        "description": "Font Joy is a website that generates font pairings for designers and developers to use in their projects. ",
-        "url": "https://fontjoy.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Type Scale",
-        "description": "A tool to create visual type scales - sets of font sizes that follow good-looking proportions.",
-        "url": "https://type-scale.com",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Fontesk",
-        "description": "Curated online font library that contains the best high-quality free fonts to download for commercial and personal use.",
-        "url": "https://fontesk.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Befonts",
-        "description": "Befonts is a platform where you can download fonts for free for personal or commercial use.",
-        "url": "https://befonts.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Fontshare",
-        "description": "Fontshare is a website that offers a wide selection of high-quality, free fonts for personal and commercial use.",
-        "url": "https://www.fontshare.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Font Awesome",
-        "description": "Font Awesome is the Internet's icon library and toolkit, used by millions of designers, developers, and content creators.",
-        "url": "https://fontawesome.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "DaFont",
-        "description": "DaFont is a versatile platform enabling users to download and share a wide range of fonts, encompassing both free and commercial options.",
-        "url": "https://www.dafont.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Adobe Fonts",
-        "description": "Adobe Fonts partners with the world's leading type foundries to bring thousands of beautiful fonts to designers every day.",
-        "url": "https://fonts.adobe.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    },
-    {
-        "name": "Fontmirror",
-        "description": "Fontmirror is a platform that contains 10000+ freely downloadable digital fonts.",
-        "url": "https://www.fontmirror.com/",
-        "category": "frontend",
-        "subcategory": "fonts"
-    }
+  {
+    "name": "Google Fonts",
+    "description": "The No. 1 resource for free and easy-to-use webfonts by Google. It has a huge library of fonts. ",
+    "url": "https://fonts.google.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Fonts Quirrel",
+    "description": "Fonts Quirrel is platform to get free commercial fonts for your project. It's another huge library for fonts ",
+    "url": "https://fontsquirrel.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "1001 fonts",
+    "description": "1001 fonts is a platform that offers 42933 free fonts in 24214 families · Free licenses for commercial use·",
+    "url": "https://www.1001fonts.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Font Joy",
+    "description": "Font Joy is a website that generates font pairings for designers and developers to use in their projects. ",
+    "url": "https://fontjoy.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Type Scale",
+    "description": "A tool to create visual type scales - sets of font sizes that follow good-looking proportions.",
+    "url": "https://type-scale.com",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Fontesk",
+    "description": "Curated online font library that contains the best high-quality free fonts to download for commercial and personal use.",
+    "url": "https://fontesk.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Befonts",
+    "description": "Befonts is a platform where you can download fonts for free for personal or commercial use.",
+    "url": "https://befonts.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Fontshare",
+    "description": "Fontshare is a website that offers a wide selection of high-quality, free fonts for personal and commercial use.",
+    "url": "https://www.fontshare.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+
+  {
+    "name": "DaFont",
+    "description": "DaFont is a versatile platform enabling users to download and share a wide range of fonts, encompassing both free and commercial options.",
+    "url": "https://www.dafont.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Adobe Fonts",
+    "description": "Adobe Fonts partners with the world's leading type foundries to bring thousands of beautiful fonts to designers every day.",
+    "url": "https://fonts.adobe.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  },
+  {
+    "name": "Fontmirror",
+    "description": "Fontmirror is a platform that contains 10000+ freely downloadable digital fonts.",
+    "url": "https://www.fontmirror.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
+  }
 ]


### PR DESCRIPTION
## Fixes Issue
closes #1955 

## Changes proposed
Removed the Font Awesome link from the Font category as it doesn't belong there.

<!-- List all the proposed changes in your PR -->

## Screenshots
![Screenshot 2023-10-13 105522](https://github.com/rupali-codes/LinksHub/assets/98448844/b436d1f8-78ee-4b18-a7a8-d4748ddd5b01)