### PR TITLE
Adding Yannickilcher channel in machine learning category

### DIFF
--- a/database/youtube/machine-learning.json
+++ b/database/youtube/machine-learning.json
@@ -86,5 +86,12 @@
     "category": "youtube",
     "subcategory": "machine-learning",
     "language": "english"
+  },
+    {
+    "name" : "YannicKilcher",
+    "description": "This channel provides consistent update on the machine learning related news and papers, and also dive deep into the specific paper. There is also a paper reading activity on the discord of this channel as well. Best suited for someone who would like to learn more about the in-depth research in machine learning.",
+    "url" : "https://www.youtube.com/@YannicKilcher",
+    "subcategory": "machine-learning",
+    "language": "english"
   }
 ]

--- a/database/youtube/machine-learning.json
+++ b/database/youtube/machine-learning.json
@@ -91,6 +91,7 @@
     "name" : "YannicKilcher",
     "description": "This channel provides consistent update on the machine learning related news and papers, and also dive deep into the specific paper. There is also a paper reading activity on the discord of this channel as well. Best suited for someone who would like to learn more about the in-depth research in machine learning.",
     "url" : "https://www.youtube.com/@YannicKilcher",
+    "category" "youtube",
     "subcategory": "machine-learning",
     "language": "english"
   }

--- a/database/youtube/machine-learning.json
+++ b/database/youtube/machine-learning.json
@@ -91,7 +91,7 @@
     "name" : "YannicKilcher",
     "description": "This channel provides consistent update on the machine learning related news and papers, and also dive deep into the specific paper. There is also a paper reading activity on the discord of this channel as well. Best suited for someone who would like to learn more about the in-depth research in machine learning.",
     "url" : "https://www.youtube.com/@YannicKilcher",
-    "category" "youtube",
+    "category" : "youtube",
     "subcategory": "machine-learning",
     "language": "english"
   }

--- a/database/youtube/machine-learning.json
+++ b/database/youtube/machine-learning.json
@@ -87,7 +87,7 @@
     "subcategory": "machine-learning",
     "language": "english"
   },
-    {
+  {
     "name" : "YannicKilcher",
     "description": "This channel provides consistent update on the machine learning related news and papers, and also dive deep into the specific paper. There is also a paper reading activity on the discord of this channel as well. Best suited for someone who would like to learn more about the in-depth research in machine learning.",
     "url" : "https://www.youtube.com/@YannicKilcher",


### PR DESCRIPTION
## Fixes Issue
 Closes #1813 

## Changes proposed

- Add the Youtube link for YannicKilcher channel and description in the machine learning category.

## Screenshots
![image](https://github.com/rupali-codes/LinksHub/assets/11440355/937f8918-6af0-4e07-8248-b38b5e112f25)

