### PR TITLE
chore: updating LICENSE section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,19 @@ _View the list of all contributors [here](https://github.com/rupali-codes/LinksH
 
 ## License 📝
 
-LinksHub is licensed under the terms of the MIT License. check out [LICENSE](https://github.com/rupali-codes/LinksHub/blob/main/LICENSE) for details.
+
+<table>
+  <tr>
+     <td>
+       <p align="center"> <img src="https://github.com/malivinayak/malivinayak/blob/main/LICENSE-Logo/MIT.png?raw=true" width="80%"></img>
+    </td>
+    <td> 
+      <img src="https://img.shields.io/badge/License-MIT-yellow.svg"/> <br> 
+LinksHub is licensed under the terms of the MIT License. check out <a href="./LICENSE">LICENSE</a> for details. <img width=2300/>
+    </td>
+  </tr>
+</table>
+
 
 <a name="support"></a>
 


### PR DESCRIPTION
## Changes proposed
- Updating the LICENSE section in the README file to enhance the presentation. Added a MIT logo, license badge and updated text with a cleaner format, including a hyperlink to the LICENSE file.

## Screenshots
![image](https://github.com/rupali-codes/LinksHub/assets/66154908/07701e47-a766-4751-a7ce-305250accd39)

