### PR TITLE
Sidebar not scrolling upto bottom in mobile devices

### DIFF
--- a/components/SideNavbar/SideNavbar.tsx
+++ b/components/SideNavbar/SideNavbar.tsx
@@ -31,7 +31,7 @@ export const SideNavbar: FC = () => {
       />
       {createPortal(
         <div
-          className={`fixed top-0 left-0 z-[100] h-full w-full folding:w-[310px] transition-all lg:hidden
+          className={`absolute top-0 left-0 z-[100] h-full w-full folding:w-[310px] transition-all lg:hidden
           ${sidebar ? 'animate-slide-in' : 'animate-slide-out'}
           `}
         >


### PR DESCRIPTION

## Fixes Issue #2069

## Changes proposed
- sidebar on mobile screen scrolls all the way to bottom

