### PR TITLE
feat(add link):  Add a new link to Novu in the backend as an email provider

### DIFF
--- a/database/backend/email-providers.json
+++ b/database/backend/email-providers.json
@@ -33,5 +33,12 @@
         "url": "https://aws.amazon.com/ses/",
         "category": "backend",
         "subcategory": "email-providers"  
+    },
+    {
+        "name": "Novu",
+        "description": "Novu is an open-source notification infrastructure that allows developers to send notifications to their users through multiple channels, including email.",
+        "url": "https://novu.co/",
+        "category": "backend",
+        "subcategory": "email-providers"
     }
 ]


### PR DESCRIPTION

<!-- If your PR fixes an open issue, use `Closes ##2110` to link your PR with the issue. #999 stands for the issue number you are fixing -->
## Fixes Issue

Closes ##2110


<!-- Example: Closes #31 -->

## Changes proposed
This commit introduces a new link to Novu.co at "backend/email-providers"

Novu is an open-source notification infrastructure that allows developers to send notifications to their users through multiple channels.
