### PR TITLE
feat(add link): Add a new link to Fontspace in the frontend as a fonts provider

### DIFF
--- a/database/frontend/fonts.json
+++ b/database/frontend/fonts.json
@@ -76,5 +76,13 @@
     "url": "https://www.fontmirror.com/",
     "category": "frontend",
     "subcategory": "fonts"
+  },
+  {
+    "name": "FontSpace",
+    "description": "FontSpace is a font directory with more than 100,000+ freely available fonts. It takes a visual approach to displaying fonts.",
+    "url": "https://www.fontspace.com/",
+    "category": "frontend",
+    "subcategory": "fonts"
   }
+
 ]

--- a/database/frontend/fonts.json
+++ b/database/frontend/fonts.json
@@ -79,7 +79,7 @@
   },
   {
     "name": "FontSpace",
-    "description": "FontSpace is a font directory with more than 100,000+ freely available fonts. It takes a visual approach to displaying fonts.",
+    "description": "FontSpace is a font directory with more than 100,000+ freely available fonts. It takes a visual approach for displaying fonts.",
     "url": "https://www.fontspace.com/",
     "category": "frontend",
     "subcategory": "fonts"

--- a/database/frontend/fonts.json
+++ b/database/frontend/fonts.json
@@ -8,7 +8,7 @@
   },
   {
     "name": "Fonts Quirrel",
-    "description": "Fonts Quirrel is platform to get free commercial fonts for your project. It's another huge library for fonts ",
+    "description": "Fonts Quirrel is platform to get free commercial fonts for your project. It's another huge library for fonts.",
     "url": "https://fontsquirrel.com/",
     "category": "frontend",
     "subcategory": "fonts"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #2113 

## Changes proposed

This commit introduces a new link to Fontspace.com at "frontend/fonts"

## About FontSpace
FontSpace is a font directory with more than 100,000 available fonts. It takes a visual approach to displaying fonts. Along with the usual editable font preview, you'll also find an image from the designer that showcases the font.