### PR TITLE
chore: add workflow to handle multiple issues

### DIFF
--- a/.github/workflows/handle-multiple-issues.yml
+++ b/.github/workflows/handle-multiple-issues.yml
@@ -1,3 +1,5 @@
+# docs: https://github.com/Anmol-Baranwal/handle-multiple-issues
+
 name: Handle Multiple Issues
 
 on:

--- a/.github/workflows/handle-multiple-issues.yml
+++ b/.github/workflows/handle-multiple-issues.yml
@@ -1,0 +1,20 @@
+name: Handle Multiple Issues
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  handle-multiple-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle Multiple Issues
+        uses: Anmol-Baranwal/handle-multiple-issues@v1
+        with:
+          label: 'multiple issues'
+          issueNumber: true
+          comment: |
+            is already opened by you
+            As per contributing guidelines, you can only work on 1 issue at a time.
+          ignoreCollaborators: true


### PR DESCRIPTION
> docs: https://github.com/Anmol-Baranwal/handle-multiple-issues

## Fixes Issue

resolves #1844 

## Changes proposed

- This will save us the trouble from checking if contributors have created issues or not.

## Note to reviewers

This is what this workflow will do.

- It will find the issues that is created by the author and is in `open` state.
- It will add a label of `multiple issues` if there are any
- It will be ignored for us as collaborators and maintainers

![image](https://github.com/rupali-codes/LinksHub/assets/74038190/432e9569-c7e1-4eda-994d-637e0dd3d840)

- It will comment a message.

![1result](https://github.com/rupali-codes/LinksHub/assets/74038190/940d4da0-f200-46be-9f59-b87a7ad84836)

```
The message will be:

#  Suppose #1 is already created by the author.
#  Output
#  #1 is already opened by you
#  As per contributing guidelines, you can only work on 1 issue at a time.
```

@rupali-codes @CBID2 @aftabrehan 
You can see the workflow, and suggest the changes.

- We can also filter if any issues are assigned to the author.
- We can multiple labels if we want.