### PR TITLE
feat: add 'IaC' sub-category with 'Terraform' content under 'devops' category

### DIFF
--- a/components/TopBar/CategoryDescriptions.ts
+++ b/components/TopBar/CategoryDescriptions.ts
@@ -111,6 +111,7 @@ const categoryDescriptions: CategoryDescriptions = {
     'Kubernetes is an open-source container orchestration platform that automates the deployment, scaling, and management of containerized applications.',
   microservices:
     'Microservices are a software development technique—a variant of the service-oriented architecture (SOA) architectural style that structures an application as a collection of loosely coupled services.',
+  IaC: 'Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes.',
 
   // AI
   'artificial intelligence':

--- a/database/data.ts
+++ b/database/data.ts
@@ -168,6 +168,11 @@ export const sidebarData: ISidebar[] = [
         url: '/microservices',
         resources: DB.microservices,
       },
+      {
+        name: 'IaC',
+        url: '/iac',
+        resources: DB.iac,
+      },
     ],
   },
   {

--- a/database/devops/iac.json
+++ b/database/devops/iac.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Terraform Documentation",
+    "description": "Terraform is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently. The official Terraform documentation serves as a comprehensive resource for users, offering detailed information, guidance, and best practices for effectively using Terraform.",
+    "url": "https://developer.hashicorp.com/terraform/docs",
+    "category": "devops",
+    "subcategory": "iac"
+  },
+  {
+    "name": "Terraform Tutorial",
+    "description": "This is a comprehensive Terraform tutorial for beginners.",
+    "url": "https://www.youtube.com/watch?v=vwn77cUarTs&list=PL8HowI-L-3_9bkocmR3JahQ4Y-Pbqs2Nt&index=1",
+    "category": "devops",
+    "subcategory": "iac"
+  }
+]

--- a/database/index.ts
+++ b/database/index.ts
@@ -34,6 +34,7 @@ export { default as docker } from './devops/docker.json'
 export { default as jenkins } from './devops/jenkins.json'
 export { default as kubernetes } from './devops/kubernetes.json'
 export { default as microservices } from './devops/microservices.json'
+export { default as iac } from './devops/iac.json'
 
 // languages
 export { default as javascript } from './languages/javascript.json'


### PR DESCRIPTION
## Fixes Issue

Closes #2203

## Changes proposed

- New sub-category under devops category called `IaC`
- Two `Terraform` content under IaC sub-category
    - Official documentation
    - Youtube course for beginners

## Screenshots

<img width="299" alt="Screenshot 2023-12-17 at 11 38 38" src="https://github.com/rupali-codes/LinksHub/assets/94709417/cb805e8f-edf9-43c7-be6a-75f0f3de040f">
<img width="1253" alt="Screenshot 2023-12-17 at 11 39 01" src="https://github.com/rupali-codes/LinksHub/assets/94709417/bcf524d0-05bf-4efe-8c98-83b9e0bb0145">


## Note to reviewers

If you have any comments, please let me know and I'll correct them as soon as possible.