### PR TITLE
#2071 Pagination buttons added at top-right corner

### DIFF
--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -1,42 +1,39 @@
-import React, { useEffect } from 'react';
-import { useTheme } from 'next-themes';
-import clsx from 'clsx';
+import React, { useEffect } from 'react'
+import { useTheme } from 'next-themes'
+import clsx from 'clsx'
 
 type PaginationProps = {
-  totalPages: number[] | null;
-  currentPage: number;
-  handlePageChange: (page: number) => void;
-};
+  totalPages: number[] | null
+  currentPage: number
+  handlePageChange: (page: number) => void
+  styles?: string
+}
 
 export default function Pagination({
   totalPages,
   currentPage,
   handlePageChange,
+  styles,
 }: PaginationProps) {
-  const { resolvedTheme } = useTheme();
-  const isDarkMode = resolvedTheme === 'dark';
+  const { resolvedTheme } = useTheme()
+  const isDarkMode = resolvedTheme === 'dark'
 
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
 
   const changePage = (page: number) => {
-    handlePageChange(page);
-  };
+    handlePageChange(page)
+  }
 
   useEffect(() => {
-    scrollToTop();
-  }, [currentPage]);
+    scrollToTop()
+  }, [currentPage])
 
   return (
     <>
       {totalPages && totalPages.length > 1 && (
-        <div
-          className={clsx(
-            'w-full z-20 flex lg:w-full items-center justify-center ',
-            'absolute bottom-2 right-0'
-          )}
-        >
+        <div className={styles}>
           <div className="flex items-center px-6 py-1 gap-4">
             <button
               className={clsx(
@@ -57,7 +54,9 @@ export default function Pagination({
                     'flex items-center justify-center rounded-md hover:bg-[#8b5cf6] hover:text-white px-2',
                     currentPage === page
                       ? 'bg-[#8b5cf6] text-white'
-                      : isDarkMode ? 'text-light' : 'text-theme-secondary'
+                      : isDarkMode
+                      ? 'text-light'
+                      : 'text-theme-secondary'
                   )}
                   onClick={() => changePage(page)}
                 >
@@ -79,5 +78,5 @@ export default function Pagination({
         </div>
       )}
     </>
-  );
+  )
 }

--- a/pages/[category]/[...subcategory].tsx
+++ b/pages/[category]/[...subcategory].tsx
@@ -9,6 +9,7 @@ import { GetStaticProps, NextPage } from 'next'
 import { ParsedUrlQuery } from 'querystring'
 import { usePagination } from 'hooks/usePagination'
 import Pagination from 'components/Pagination/Pagination'
+import clsx from 'clsx'
 
 interface PageProps {
   category: string
@@ -101,11 +102,24 @@ const SubCategory: NextPage<PageProps> = ({ subcategory }) => {
         className="relative min-h-[calc(100%-68px)] w-full pt-[85px] pb-4 md:min-h-[calc(100%-76px)] md:px-10 md:pt-10"
       >
         {content}
-        <div className="min-w-full h-10 py-5"/>
+        <div className="min-w-full h-10 py-5" />
         <Pagination
           totalPages={totalPages}
           currentPage={currentPage}
           handlePageChange={handlePageChange}
+          styles={`${clsx(
+            'hidden md:flex w-full z-20 items-center justify-end',
+            'absolute top-0 right-0'
+          )}`}
+        />
+        <Pagination
+          totalPages={totalPages}
+          currentPage={currentPage}
+          handlePageChange={handlePageChange}
+          styles={`${clsx(
+            'w-full z-20 flex lg:w-full items-center justify-center',
+            'absolute bottom-2 right-0'
+          )}`}
         />
       </div>
     </>


### PR DESCRIPTION
## Fixes Issue
I have worked on Issue#2071

## Changes proposed

1) Added the pagination buttons at the top-right corner of the page without removing them from the bottom.
2) Maintained site's responsiveness while fixing this.

## Screenshots
![img-1](https://github.com/rupali-codes/LinksHub/assets/96867955/0a0de0b7-7292-47b9-9a55-655225e91f2a)
![img-2](https://github.com/rupali-codes/LinksHub/assets/96867955/8cc47944-cf6a-47ec-a2a0-b4f0132254fe)
