### PR TITLE
Change threeJS subcategory name to 3d libraries and add resource links

### DIFF
--- a/components/TopBar/CategoryDescriptions.ts
+++ b/components/TopBar/CategoryDescriptions.ts
@@ -30,8 +30,8 @@ const categoryDescriptions: CategoryDescriptions = {
     'Theme templates are pre-designed website themes that can be customized to fit your needs. They are useful for quickly setting up a website without having to design everything from scratch.',
   videos:
     'Videos are visual representations of moving images and sound. They can be used to convey information in a simple and easy-to-understand way.',
-  'three-js':
-    'Three.js is a cross-browser JavaScript library and application programming interface (API) used to create and display animated 3D computer graphics in a web browser using WebGL.',
+  '3D-libraries':
+    '3D libraries are collections of reusable components that can be used to create 3D graphics and animations. They are often used in conjunction with frameworks like Three.js to create web applications.',
   'next-js':
     'Next.js is a flexible React framework that gives you building blocks to create fast web applications.',
   'ui-generators':

--- a/components/TopBar/CategoryDescriptions.ts
+++ b/components/TopBar/CategoryDescriptions.ts
@@ -30,8 +30,8 @@ const categoryDescriptions: CategoryDescriptions = {
     'Theme templates are pre-designed website themes that can be customized to fit your needs. They are useful for quickly setting up a website without having to design everything from scratch.',
   videos:
     'Videos are visual representations of moving images and sound. They can be used to convey information in a simple and easy-to-understand way.',
-  '3D-libraries':
-    '3D libraries are collections of reusable components that can be used to create 3D graphics and animations. They are often used in conjunction with frameworks like Three.js to create web applications.',
+  '3d-libraries':
+    '3D Libraries are collections of reusable components that can be used to create 3D graphics and animations. They are often used in conjunction with frameworks like Three.js to create web applications.',
   'next-js':
     'Next.js is a flexible React framework that gives you building blocks to create fast web applications.',
   'ui-generators':

--- a/database/data.ts
+++ b/database/data.ts
@@ -10,7 +10,11 @@ export const sidebarData: ISidebar[] = [
     category: 'frontend',
     subcategory: [
       { name: 'next js', url: '/next-js', resources: DB.next },
-      { name: 'three js', url: '/three-js', resources: DB.three },
+      {
+        name: '3D libraries',
+        url: '/3d-libraries',
+        resources: DB._3dLibraries,
+      },
       { name: 'images', url: '/images', resources: DB.images },
       { name: 'fonts', url: '/fonts', resources: DB.fonts },
       { name: 'colors', url: '/colors', resources: DB.colors },

--- a/database/frontend/3d-libraries.json
+++ b/database/frontend/3d-libraries.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Three JS",
+    "description": "The world's most popular JavaScript framework for displaying 3D content on the web. With three.js, you no longer need a fancy gaming PC console or download a special application to display photorealistic 3D graphics. All you need is a smartphone and a web browser.",
+    "url": "https://threejs.org/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "Babylon JS",
+    "description": "One of the world's leading WebGL-based graphics engines. From a new visual scene inspector, best-in-class physically-based rendering, countless performance optimizations, and much more, Babylon.js brings powerful, beautiful, simple, and open 3D to everyone on the web.",
+    "url": "https://www.babylonjs.com/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "A-Frame",
+    "description": "An open-source web framework for building virtual reality (VR) experiences. It is based on top of HTML, making it simple to get started. But it is not just a 3D scene graph or a markup language; the core is a powerful entity-component framework that provides a declarative, extensible, and composable structure to three.js.",
+    "url": "https://aframe.io/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "PlayCanvas",
+    "description": "The world's easiest to use WebGL Game Engine. It's free, it's open source and it's backed by amazing developer tools.",
+    "url": "https://playcanvas.com/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "Cannon JS",
+    "description": "A physics engine for the web. It's written in JavaScript and runs in the browser. It's a great choice for building 3D games and simulations in the browser. It's open-source and free to use.",
+    "url": "https://schteppe.github.io/cannon.js/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "Oimo JS",
+    "description": "A 3D physics engine for the web. It's written in JavaScript and runs in the browser. It's a great choice for building 3D games and simulations in the browser. It's open-source and free to use.",
+    "url": "https://lo-th.github.io/Oimo.js/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "Cesium JS",
+    "description": "CesiumJS is an open-source JavaScript library for creating world-class 3D globes and maps with the best possible performance, precision, visual quality, and ease of use.",
+    "url": "https://cesium.com/cesiumjs/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "X3DOM",
+    "description": "A framework for integrating and manipulating 3D content in an HTML5 context. It uses the W3C X3D standard and is open-source and free to use.",
+    "url": "https://www.x3dom.org/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "Verge3D",
+    "description": "A powerful and intuitive toolkit that allows Blender, 3ds Max, or Maya users to create immersive web-based experiences. Verge3D can be used to build interactive animations, product configurators, engaging presentations of any kind, online stores, explainers, e-learning content, portfolios, and browser games.",
+    "url": "https://www.soft8soft.com/verge3d/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  },
+  {
+    "name": "P5 JS",
+    "description": "A JavaScript library for creative coding, with a focus on making coding accessible and inclusive for artists, designers, educators, beginners, and anyone else! p5.js is free and open-source because we believe software, and the tools to learn it, should be accessible to everyone.",
+    "url": "https://p5js.org/",
+    "category": "frontend",
+    "subcategory": "3d-libraries"
+  }
+]

--- a/database/frontend/three.json
+++ b/database/frontend/three.json
@@ -1,9 +1,0 @@
-[
-    {
-      "name": "ThreeJS",
-      "description": "Three.js is the world's most popular JavaScript framework for displaying 3D content on the web. With three.js, you no longer need a fancy gaming PC console or download a special application to display photorealistic 3D graphics. All you need is a smartphone and a web browser.",
-      "url": "https://discoverthreejs.com/",
-      "category": "frontend",
-      "subcategory": "three-js"
-    }
-  ]

--- a/database/index.ts
+++ b/database/index.ts
@@ -14,7 +14,7 @@ export { default as themesTemplates } from './frontend/themes-templates.json'
 export { default as uiGenerators } from './frontend/ui-generators.json'
 export { default as react } from './frontend/react.json'
 export { default as next } from './frontend/next.json'
-export { default as three } from './frontend/three.json'
+export { default as _3dLibraries } from './frontend/3d-libraries.json'
 export { default as uilibraries } from './frontend/ui-libraries.json'
 // backend
 export { default as authentication } from './backend/authentication.json'


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #2270 : Change threeJS subcategory name to 3d libraries and add resource links

## Changes proposed

- Change the subCategory called **threeJS** under the frontend _category_ to **3D Libraries**
- Modify the `CategoryDescriptions.ts` file to include 3D Libraries.
- Rename file called `three.json` in the frontend database folder to include all the URLs related to 3D Libraries.
- Modify the `index.ts` file in the database folder to include 3D Libraries.
- Modify the `data.ts` file in the database folder to include 3D Libraries.


## Screenshots

![3D Libraries](https://github.com/rupali-codes/LinksHub/assets/25883220/296c8e3d-3a6a-49d8-a443-f7e060ebf2a0)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->