### PR TITLE
Closes #2302

### DIFF
--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useTheme } from 'next-themes'
 import clsx from 'clsx'
 import { MdArrowForwardIos } from 'react-icons/md'
@@ -20,13 +20,30 @@ export default function Pagination({
 }: PaginationProps) {
   const { resolvedTheme } = useTheme()
   const isDarkMode = resolvedTheme === 'dark'
+  const [scrollingElement, setScrollingElement] = useState<HTMLElement | Window | undefined>()
+  const paginationRef = useRef<HTMLDivElement>(null);
+
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    if (scrollingElement) scrollingElement.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   const changePage = (page: number) => {
     handlePageChange(page)
   }
+
+  useEffect(() => {
+    if (paginationRef.current) {
+      const findClosestScrollElement = (element: HTMLElement | null): HTMLElement | Window => {
+        if (!element) return window
+        const { overflowY } = getComputedStyle(element)
+        const scrollableVariants = ['auto', 'scroll']
+        return scrollableVariants.some(v => overflowY === v)
+            ? element
+            : findClosestScrollElement(element.parentElement)
+      }
+      setScrollingElement(findClosestScrollElement(paginationRef.current))
+    }
+  }, [])
 
   useEffect(() => {
     scrollToTop()
@@ -37,7 +54,7 @@ export default function Pagination({
   return (
     <>
       {totalPages && totalPages.length > 1 && (
-        <div>
+        <div ref={paginationRef}>
           <div
             className={
               currentPage == totalPages.length && remainderOfCards <= 3


### PR DESCRIPTION
## Fixes Issue

This pr closes #2302 

## Changes proposed

added findClosestScrollElement function inside useEffect on first render of pagination
that function will find closest scrolling element and use it for scrolling when user changes page
Use that behavior in order to prevent bugs in future when pagination could be implemented in any part of a project Or the main scrolling element will be changed
that fix prevents almost all future scrolling bugs here  

## Screenshots
Small screencast to demonstrate how it works now
[Screencast from 03-17-2024 12:34:25 PM.webm](https://github.com/rupali-codes/LinksHub/assets/78084319/bed0008c-03dc-44f6-a1df-f5343deb88a8)

## Note to reviewers

Thank you for opportunity to contribute to your project!
I open for any discussion feel free to ask any questions and leave comments)