### PR TITLE
feat: [ADD]-Sub Category- Automation Tools #2345

### DIFF
--- a/database/data.ts
+++ b/database/data.ts
@@ -156,7 +156,16 @@ export const sidebarData: ISidebar[] = [
   {
     category: 'devops',
     subcategory: [
-      { name: 'CI/CD', url: '/cicd', resources: DB.cicd },
+      {
+        name: 'Automation Tools', 
+        url: '/automation-tools', 
+        resources: DB.automationTools, 
+      },
+      {
+         name: 'CI/CD', 
+         url: '/cicd', 
+         resources: DB.cicd 
+      },
       {
         name: 'DevOps Life Cycle',
         url: '/devops-life-cycle',

--- a/database/devops/automation-tools.json
+++ b/database/devops/automation-tools.json
@@ -1,0 +1,33 @@
+[
+    {
+        "name": "Ansible Automation",
+        "description": "Implement Ansible for streamlined automation of infrastructure and deployment.",
+        "url": "https://www.ansible.com/",
+        "category": "devops",
+        "subcategory": "automation-tools"
+    },
+
+    {
+        "name": "Terraform Infrastructure",
+        "description": "Automate infrastructure provisioning with Terraform for scalable, consistent deployments.",
+        "url": "https://www.terraform.io/",
+        "category": "devops",
+        "subcategory": "automation-tools"
+    },
+
+    {
+        "name": "GitLab CI/CD",
+        "description": "Automate testing, building, and deploying with GitLab CI/CD pipelines.",
+        "url": "https://docs.gitlab.com/ee/ci/",
+        "category": "devops",
+        "subcategory": "automation-tools"
+    },
+
+    {
+        "name": "Configuration Management with Puppet and Chef",
+        "description": "Automate server configuration with Puppet and Chef for consistency and compliance.",
+        "url": "https://www.puppet.com/",
+        "category": "devops",
+        "subcategory": "automation-tools"
+    }
+]   

--- a/database/index.ts
+++ b/database/index.ts
@@ -30,6 +30,7 @@ export { default as api } from './backend/api.json'
 export { default as emailProviders } from './backend/email-providers.json'
 
 //devops
+export { default as automationTools } from './devops/automation-tools.json'
 export { default as cicd } from './devops/cicd.json'
 export { default as devopsLifecycle } from './devops/devops-life-cycle.json'
 export { default as devopsMethodologies } from './devops/devops-methodologies.json'


### PR DESCRIPTION
closes #2345 

## Add Sub Category
Adding a sub category named Automation Tools where, insert various tools in this category.

## Screenshots
![image](https://github.com/rupali-codes/LinksHub/assets/100375390/1f45b823-96d9-4695-ad82-5bc2cb3ab3b3)
---
![image](https://github.com/rupali-codes/LinksHub/assets/100375390/7497f49e-3141-4d9d-b5cc-8261583b4030)
---

## Links I have posted
- **Ansible Automation**- [view](https://www.ansible.com/)
- **Terraform Infrastructure**- [View](https://www.terraform.io/)
- **GitLab CI/CD**- [View](https://docs.gitlab.com/ee/ci/)
- **Configuration Management with Puppet and Chef**- [View](https://www.puppet.com/)

> @Anmol-Baranwal Anmol, is this correct, or should I post a link to another website? Please let me know if there are any issues with the tools.
