### PR TITLE
added FreeAPIs link to backend/api

### DIFF
--- a/database/backend/api.json
+++ b/database/backend/api.json
@@ -131,5 +131,12 @@
         "url": "https://api.nasa.gov",
         "category": "backend",
         "subcategory": "api"
+    },
+    {
+        "name": "Free APIs",
+        "description": "It's a collection of free APIs. Curated Playground for the Best Public Web APIs!",
+        "url": "https://apislist.com/",
+        "category": "backend",
+        "subcategory": "api"
     }
 ]


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #2364 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
It adds a new link to 'Free APIs' in the `backend/api` section in the website.