### PR TITLE
fix: package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LinksHub",
+  "name": "links-hub",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Changes proposed

This PR changes the `name` property in `package.json` file as it does not follow the naming conventions.
Renamed to `links-hub`.

## Screenshots
![linkshub package](https://github.com/user-attachments/assets/7160bb32-bcf4-40c1-a383-32711d8e07ba)