### PR TITLE
chore(typo): rename our team button

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -61,6 +61,7 @@ export const Header: FC = () => {
     label: 'Saved',
     href: '/saved',
     isDisabled: true,
+    isActive: router.asPath.startsWith('/saved'),
   }
 
   const renderLinks = () =>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -47,18 +47,18 @@ export const Header: FC = () => {
 
   const navLinks = [
     {
-      inActiveIcon: <Icons.teamInactive className={inActiveIconCls} />,
-      activeIcon: <Icons.teamActive className={activeIconCls} />,
-      label: 'Team',
-      href: '/contributors',
-      isDisabled: false,
-    },
-    {
       inActiveIcon: <Icons.saveInactive className={inActiveIconCls} />,
       activeIcon: <Icons.saveActive className={activeIconCls} />,
       label: 'Saved',
       href: '/saved',
       isDisabled: true,
+    },
+    {
+      inActiveIcon: <Icons.teamInactive className={inActiveIconCls} />,
+      activeIcon: <Icons.teamActive className={activeIconCls} />,
+      label: 'Team',
+      href: '/contributors',
+      isDisabled: false,
     }
   ]
 

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -47,13 +47,6 @@ export const Header: FC = () => {
 
   const navLinks = [
     {
-      inActiveIcon: <Icons.saveInactive className={inActiveIconCls} />,
-      activeIcon: <Icons.saveActive className={activeIconCls} />,
-      label: 'Saved',
-      href: '/saved',
-      isDisabled: true,
-    },
-    {
       inActiveIcon: <Icons.teamInactive className={inActiveIconCls} />,
       activeIcon: <Icons.teamActive className={activeIconCls} />,
       label: 'Team',
@@ -61,6 +54,14 @@ export const Header: FC = () => {
       isDisabled: false,
     },
   ]
+
+  const savedLink = {
+    inActiveIcon: <Icons.saveInactive className={inActiveIconCls} />,
+    activeIcon: <Icons.saveActive className={activeIconCls} />,
+    label: 'Saved',
+    href: '/saved',
+    isDisabled: true,
+  }
 
   const renderLinks = () =>
     navLinks.map(({ inActiveIcon, activeIcon, label, href }, i) => {
@@ -95,6 +96,17 @@ export const Header: FC = () => {
         <Link href="/" aria-label="LinksHub Logo">
           <Logo />
         </Link>
+          <Link
+            href={savedLink.href}
+            className={`hover:bg-slate-100 hover:bg-opacity-50 dark:hover:bg-zinc-400 dark:hover:bg-opacity-10 flex items-center justify-start p-2 gap-2 text-base font-medium leading-5 rounded-xl ${
+              savedLink.isActive ? 'text-primary dark:text-white' : 'text-gray-text'
+            }`}
+          >
+            <span className="flex items-center justify-center" title={savedLink.label}>
+              {savedLink.isActive ? savedLink.activeIcon : savedLink.inActiveIcon}
+            </span>
+            <span>{savedLink.label}</span>
+          </Link>
       </div>
 
       <div className="flex items-center justify-center gap-6">

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import Link from 'next/link'
-import clsx from 'clsx'
 import { useRouter } from 'next/router'
 
 import { ThemeToggler } from 'components/ThemeToggler/themeToggler'
@@ -11,36 +10,6 @@ import { Icons } from 'components/icons'
 
 export const Header: FC = () => {
   const router = useRouter()
-
-  const iconClass =
-    'text-zinc-600 group-hover:text-primary dark:text-zinc-400 dark:group-hover:text-slate-300 h-6 w-6'
-  const socialIcons = [
-    {
-      icon: <Icons.X className={iconClass} />,
-      title: 'X (Twitter)',
-      href: 'https://twitter.com/linkshubdotdev',
-      ariaLabel: 'Follow us on X(Twitter)',
-    },
-    {
-      icon: <Icons.Linkedin className={iconClass} />,
-      title: 'Linkedin',
-      href: 'https://www.linkedin.com/company/linkshub-dev',
-      ariaLabel: 'Follow us on Linkedin',
-    },
-    {
-      icon: <Icons.Discord className={iconClass} />,
-      title: 'Discord',
-      href: 'https://discord.com/invite/NvK67YnJX5',
-      ariaLabel: 'Join the Community',
-    },
-    {
-      icon: <Icons.GitHub className={iconClass} />,
-      title: 'Github',
-      href: 'https://github.com/rupali-codes/LinksHub',
-      ariaLabel: 'Explore on GitHub',
-      showOnMobile: true,
-    },
-  ]
 
   const inActiveIconCls = 'stroke-gray-400'
   const activeIconCls = 'text-primary dark:text-white'
@@ -110,31 +79,11 @@ export const Header: FC = () => {
           </Link>
       </div>
 
-      <div className="flex items-center justify-center gap-6">
+      <div className="flex items-center justify-center gap-2">
         <nav className="w-full flex md:block hidden">
           <ul className="w-full flex gap-0.5 tall:gap-1">{renderLinks()}</ul>
         </nav>
-        <div className="flex items-center justify-center gap-[14px]">
-          {socialIcons.map(
-            ({ icon, title, href, ariaLabel, showOnMobile }, i) => (
-              <Link
-                key={i}
-                href={href}
-                title={title}
-                aria-label={ariaLabel}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={clsx(
-                  'group flex items-center justify-center rounded-md hover:bg-slate-100 dark:hover:bg-white dark:hover:bg-opacity-20 transition-colors',
-                  showOnMobile ? '' : 'hidden sm:flex'
-                )}
-              >
-                {icon}
-              </Link>
-            )
-          )}
-          <ThemeToggler />
-        </div>
+        <ThemeToggler />
       </div>
     </header>
   )

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -56,7 +56,7 @@ export const Header: FC = () => {
     {
       inActiveIcon: <Icons.teamInactive className={inActiveIconCls} />,
       activeIcon: <Icons.teamActive className={activeIconCls} />,
-      label: 'Our Team',
+      label: 'Team',
       href: '/contributors',
       isDisabled: false,
     },
@@ -124,7 +124,7 @@ export const Header: FC = () => {
         </div>
 
         <Button
-          label="Sponsor"
+		  label="Sponser"
           icon={<Icons.heart className="h-5 w-5" />}
           variant="pale"
           link="https://github.com/sponsors/rupali-codes"

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import Link from 'next/link'
+import clsx from 'clsx'
 import { useRouter } from 'next/router'
 
 import { ThemeToggler } from 'components/ThemeToggler/themeToggler'
@@ -10,6 +11,36 @@ import { Icons } from 'components/icons'
 
 export const Header: FC = () => {
   const router = useRouter()
+
+  const iconClass =
+    'text-zinc-600 group-hover:text-primary dark:text-zinc-400 dark:group-hover:text-slate-300 h-6 w-6'
+  const socialIcons = [
+    {
+      icon: <Icons.X className={iconClass} />,
+      title: 'X (Twitter)',
+      href: 'https://twitter.com/linkshubdotdev',
+      ariaLabel: 'Follow us on X(Twitter)',
+    },
+    {
+      icon: <Icons.Linkedin className={iconClass} />,
+      title: 'Linkedin',
+      href: 'https://www.linkedin.com/company/linkshub-dev',
+      ariaLabel: 'Follow us on Linkedin',
+    },
+    {
+      icon: <Icons.Discord className={iconClass} />,
+      title: 'Discord',
+      href: 'https://discord.com/invite/NvK67YnJX5',
+      ariaLabel: 'Join the Community',
+    },
+    {
+      icon: <Icons.GitHub className={iconClass} />,
+      title: 'Github',
+      href: 'https://github.com/rupali-codes/LinksHub',
+      ariaLabel: 'Explore on GitHub',
+      showOnMobile: true,
+    },
+  ]
 
   const inActiveIconCls = 'stroke-gray-400'
   const activeIconCls = 'text-primary dark:text-white'
@@ -22,16 +53,14 @@ export const Header: FC = () => {
       href: '/contributors',
       isDisabled: false,
     },
+    {
+      inActiveIcon: <Icons.saveInactive className={inActiveIconCls} />,
+      activeIcon: <Icons.saveActive className={activeIconCls} />,
+      label: 'Saved',
+      href: '/saved',
+      isDisabled: true,
+    }
   ]
-
-  const savedLink = {
-    inActiveIcon: <Icons.saveInactive className={inActiveIconCls} />,
-    activeIcon: <Icons.saveActive className={activeIconCls} />,
-    label: 'Saved',
-    href: '/saved',
-    isDisabled: true,
-    isActive: router.asPath.startsWith('/saved'),
-  }
 
   const renderLinks = () =>
     navLinks.map(({ inActiveIcon, activeIcon, label, href }, i) => {
@@ -66,24 +95,41 @@ export const Header: FC = () => {
         <Link href="/" aria-label="LinksHub Logo">
           <Logo />
         </Link>
-          <Link
-            href={savedLink.href}
-            className={`hover:bg-slate-100 hover:bg-opacity-50 dark:hover:bg-zinc-400 dark:hover:bg-opacity-10 flex items-center justify-start p-2 gap-2 text-base font-medium leading-5 rounded-xl ${
-              savedLink.isActive ? 'text-primary dark:text-white' : 'text-gray-text'
-            }`}
-          >
-            <span className="flex items-center justify-center" title={savedLink.label}>
-              {savedLink.isActive ? savedLink.activeIcon : savedLink.inActiveIcon}
-            </span>
-            <span>{savedLink.label}</span>
-          </Link>
       </div>
 
-      <div className="flex items-center justify-center gap-2">
+      <div className="flex items-center justify-center gap-6">
         <nav className="w-full flex md:block hidden">
           <ul className="w-full flex gap-0.5 tall:gap-1">{renderLinks()}</ul>
         </nav>
-        <ThemeToggler />
+        <div className="flex items-center justify-center gap-[14px]">
+          {socialIcons.map(
+            ({ icon, title, href, ariaLabel, showOnMobile }, i) => (
+              <Link
+                key={i}
+                href={href}
+                title={title}
+                aria-label={ariaLabel}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={clsx(
+                  'group flex items-center justify-center rounded-md hover:bg-slate-100 dark:hover:bg-white dark:hover:bg-opacity-20 transition-colors',
+                  showOnMobile ? '' : 'hidden sm:flex'
+                )}
+              >
+                {icon}
+              </Link>
+            )
+          )}
+          <ThemeToggler />
+        </div>
+
+        <Button
+          label="Sponsor"
+          icon={<Icons.heart className="h-5 w-5" />}
+          variant="pale"
+          link="https://github.com/sponsors/rupali-codes"
+          className="hidden sm:flex"
+        />
       </div>
     </header>
   )

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -134,14 +134,6 @@ export const Header: FC = () => {
           )}
           <ThemeToggler />
         </div>
-
-        <Button
-		  label="Sponser"
-          icon={<Icons.heart className="h-5 w-5" />}
-          variant="pale"
-          link="https://github.com/sponsors/rupali-codes"
-          className="hidden sm:flex"
-        />
       </div>
     </header>
   )


### PR DESCRIPTION
## Issue
Closes #2438 

## Changes proposed

1. Rename "Our Team" to "Team", as the word "our" also includes the reader (which may or may not be the part of the team).