### PR TITLE
chore(refactor): typo in category page

### DIFF
--- a/pages/[category]/index.tsx
+++ b/pages/[category]/index.tsx
@@ -22,7 +22,7 @@ const CategoryPage = () => {
       }
     }
 
-    return 'No descrition'
+    return 'No description'
   }
 
   return (


### PR DESCRIPTION
## Fixes Issue
Closes #2449 

## Changes proposed

Rename `"descrition"` to `"description"`