### PR TITLE
chore: rename package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LinksHub",
+  "name": "linkshub",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Fixes Issue

Closes #2436 

## Changes proposed

renames the package name to "linkshub"