### PR TITLE
fix: key prop bug

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -71,7 +71,6 @@ export const Header: FC = () => {
       const isActive = label === 'Home' ? isHomeActive : isUrlMatched
 
       return (
-        <>
           <li key={i}>
             <a
               href={href}
@@ -85,7 +84,6 @@ export const Header: FC = () => {
               <span>{label}</span>
             </a>
           </li>
-        </>
       )
     })
 


### PR DESCRIPTION
## Fixes Issue

Closes #2439 

## Changes proposed

Removes redundant React Fragment: `<></>` from the `renderLinks()` function in `components/Header/Header.tsx`