### PR TITLE
fix: broken link

### DIFF
--- a/database/youtube/web_development.json
+++ b/database/youtube/web_development.json
@@ -346,7 +346,7 @@
   {
     "name": "Hitesh Choudhary",
     "description": "It is an underrated channel for Web Development, Android development, DevOps, and more",
-    "url": "https://www.youtube.com/@HiteshChoudharydotcom",
+    "url": "https://www.youtube.com/@HiteshCodeLab",
     "category": "youtube",
     "subcategory": "web_development",
     "language": "english"


### PR DESCRIPTION
## Fixes Issue

Closes #2471

## Changes proposed

Fixes a youtube broken link in youtube/web_dev

## Note to reviewers

The report generated by github actions in #2471 has only one broken link.
Other links in the error reports works fine