### PR TITLE
chore: Add Virtual Coffee podcast link (#2479)

### DIFF
--- a/database/other/podcasts.json
+++ b/database/other/podcasts.json
@@ -26,5 +26,12 @@
     "url": "https://www.youtube.com/@AI.Overpowered",
     "category": "other",
     "subcategory": "podcasts"
+  },
+  {
+    "name": "Virtual Coffee",
+    "description": "Virtual Coffee is an intimate community for developers at all stages of the journey. It is a place to ask questions, share knowledge, and build friendships.",
+    "url": "https://virtualcoffee.io/podcast",
+    "category": "other",
+    "subcategory": "podcasts"
   }
 ]


### PR DESCRIPTION
## Fixes Issue

Closes #2479

## Changes proposed

- Added "Virtual Coffee" podcast link to `other/podcasts` category.

## Screenshots

### [Before Changes]
<img width="1223" alt="Screenshot 2024-08-30 at 17 24 11" src="https://github.com/user-attachments/assets/6f19bf2b-595a-4455-9e04-f08d8d64b204">

### [After Changes]
<img width="1237" alt="Screenshot 2024-08-30 at 17 22 27" src="https://github.com/user-attachments/assets/2b47827c-98db-4066-bac4-1288a82e04dd">

## Note to reviewers

Please review the added link and ensure it follows the project's contribution guidelines.