### PR TITLE
feat: add Abbreve project link to open_source/projects.json

### DIFF
--- a/database/open_source/projects.json
+++ b/database/open_source/projects.json
@@ -194,5 +194,12 @@
     "url": "https://productive-hub.com/",
     "category": "open-source",
     "subcategory": "projects"
+  },
+  {
+    "name":"Abbreve",
+    "description":"Abbreve is an open-source dictionary for slang. With Abbreve, you'll never have to feel left out of a conversation or unsure of the meaning of an abbreviation again.",
+    "url":"https://github.com/Njong392/Abbreve",
+    "category":"open-source",
+    "subcategory":"projects"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "git": "^0.1.5",
     "next": "13.4.3",
     "next-themes": "^0.2.1",
-    "pnpm": "^8.15.8",
+    "pnpm": "^8.15.9",
     "prettier": "^2.8.8",
     "react": "18.2.0",
     "react-autosuggest": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 3.3.3
       daisyui:
         specifier: ^2.52.0
-        version: 2.52.0(autoprefixer@10.4.19)(postcss@8.4.38)
+        version: 2.52.0(autoprefixer@10.4.19(postcss@8.4.38))(postcss@8.4.38)
       eslint:
         specifier: 8.37.0
         version: 8.37.0
@@ -58,13 +58,13 @@ importers:
         version: 0.1.5
       next:
         specifier: 13.4.3
-        version: 13.4.3(@babel/core@7.24.6)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@13.4.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 0.2.1(next@13.4.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       pnpm:
-        specifier: ^8.15.8
-        version: 8.15.8
+        specifier: ^8.15.9
+        version: 8.15.9
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -79,19 +79,19 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-helmet-async:
         specifier: ^1.3.0
-        version: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+        version: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-icons:
         specifier: ^4.12.0
         version: 4.12.0(react@18.2.0)
       react-spinners:
         specifier: ^0.13.8
-        version: 0.13.8(react-dom@18.2.0)(react@18.2.0)
+        version: 0.13.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-tooltip:
         specifier: ^5.26.4
-        version: 5.26.4(react-dom@18.2.0)(react@18.2.0)
+        version: 5.26.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-transition-state:
         specifier: ^2.1.1
-        version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
+        version: 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.3.0
@@ -100,7 +100,7 @@ importers:
         version: 5.0.3
       typewriter-effect:
         specifier: ^2.21.0
-        version: 2.21.0(react-dom@18.2.0)(react@18.2.0)
+        version: 2.21.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       uuid:
         specifier: 9.0.0
         version: 9.0.0
@@ -110,7 +110,7 @@ importers:
         version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.37.0)(typescript@5.0.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint@8.37.0)(typescript@5.0.3)
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.38)
@@ -3181,8 +3181,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  pnpm@8.15.8:
-    resolution: {integrity: sha512-0aAp4aRHrZC8ls1YsPrUhtKZPVMYVjlve6vy2D6xgju4PFo9D8GPZ1stEDIdSesWH+zjb+gTSqWCPs0hX+7Tkg==}
+  pnpm@8.15.9:
+    resolution: {integrity: sha512-SZQ0ydj90aJ5Tr9FUrOyXApjOrzuW7Fee13pDzL0e1E6ypjNXP0AHDHw20VLw4BO3M1XhQHkyik6aBYWa72fgQ==}
     engines: {node: '>=16.14'}
     hasBin: true
 
@@ -5402,7 +5402,7 @@ snapshots:
       '@babel/types': 7.24.6
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.0.3))':
     dependencies:
       '@babel/core': 7.24.6
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.6)
@@ -5412,7 +5412,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.0.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.0.3))(typescript@5.0.3)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.0.3)
       cosmiconfig: 8.3.6(typescript@5.0.3)
@@ -5429,8 +5429,8 @@ snapshots:
       '@babel/preset-react': 7.24.6(@babel/core@7.24.6)
       '@babel/preset-typescript': 7.24.6(@babel/core@7.24.6)
       '@svgr/core': 8.1.0(typescript@5.0.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.0.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.0.3))(typescript@5.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5567,7 +5567,7 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.37.0)(typescript@5.0.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint@8.37.0)(typescript@5.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
@@ -5581,6 +5581,7 @@ snapshots:
       natural-compare-lite: 1.4.0
       semver: 7.6.2
       tsutils: 3.21.0(typescript@5.0.3)
+    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5592,6 +5593,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
       debug: 4.3.4
       eslint: 8.37.0
+    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5608,6 +5610,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.37.0
       tsutils: 3.21.0(typescript@5.0.3)
+    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5623,6 +5626,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.2
       tsutils: 3.21.0(typescript@5.0.3)
+    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6037,6 +6041,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.0.3
 
   cross-spawn@7.0.3:
@@ -6078,7 +6083,7 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  daisyui@2.52.0(autoprefixer@10.4.19)(postcss@8.4.38):
+  daisyui@2.52.0(autoprefixer@10.4.19(postcss@8.4.38))(postcss@8.4.38):
     dependencies:
       autoprefixer: 10.4.19(postcss@8.4.38)
       color: 4.2.3
@@ -6355,11 +6360,12 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
       eslint: 8.37.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.37.0)
       eslint-plugin-react: 7.34.2(eslint@8.37.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.37.0)
+    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -6377,13 +6383,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.1
       eslint: 8.37.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0))(eslint@8.37.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -6394,19 +6400,19 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0))(eslint@8.37.0):
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
       eslint: 8.37.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0):
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -6415,7 +6421,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.37.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.37.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.37.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.37.0))(eslint@8.37.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6425,6 +6431,8 @@ snapshots:
       object.values: 1.2.0
       semver: 6.3.1
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.37.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7555,13 +7563,13 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-themes@0.2.1(next@13.4.3)(react-dom@18.2.0)(react@18.2.0):
+  next-themes@0.2.1(next@13.4.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 13.4.3(@babel/core@7.24.6)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@13.4.3(@babel/core@7.24.6)(react-dom@18.2.0)(react@18.2.0):
+  next@13.4.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 13.4.3
       '@swc/helpers': 0.5.1
@@ -7736,7 +7744,7 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  pnpm@8.15.8: {}
+  pnpm@8.15.9: {}
 
   possible-typed-array-names@1.0.0: {}
 
@@ -7755,8 +7763,9 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.38):
     dependencies:
       lilconfig: 3.1.1
-      postcss: 8.4.38
       yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.38
 
   postcss-nested@6.0.1(postcss@8.4.38):
     dependencies:
@@ -7923,7 +7932,7 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-helmet-async@1.3.0(react-dom@18.2.0)(react@18.2.0):
+  react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.6
       invariant: 2.2.4
@@ -7939,7 +7948,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-spinners@0.13.8(react-dom@18.2.0)(react@18.2.0):
+  react-spinners@0.13.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7948,14 +7957,14 @@ snapshots:
     dependencies:
       object-assign: 3.0.0
 
-  react-tooltip@5.26.4(react-dom@18.2.0)(react@18.2.0):
+  react-tooltip@5.26.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@floating-ui/dom': 1.6.5
       classnames: 2.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-transition-state@2.1.1(react-dom@18.2.0)(react@18.2.0):
+  react-transition-state@2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8269,9 +8278,10 @@ snapshots:
 
   styled-jsx@5.1.1(@babel/core@7.24.6)(react@18.2.0):
     dependencies:
-      '@babel/core': 7.24.6
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.24.6
 
   sucrase@3.35.0:
     dependencies:
@@ -8475,7 +8485,7 @@ snapshots:
 
   typescript@5.0.3: {}
 
-  typewriter-effect@2.21.0(react-dom@18.2.0)(react@18.2.0):
+  typewriter-effect@2.21.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       prop-types: 15.8.1
       raf: 3.4.1


### PR DESCRIPTION
## Fixes Issue
Closes #2502 

## Changes proposed
-Added  Abbreve open source project link to open_source/projects.json.

-Abbreve is an open-source dictionary for slang. With Abbreve, you'll never have to feel left out of a conversation or unsure of the meaning of an abbreviation again.

## Screenshots
![linkhub](https://github.com/user-attachments/assets/c58eddae-1007-4c24-b9ab-39796da6b179)

## Note to reviewers
- No major changes to functionality, only data addition.

