### PR TITLE
chore: fixed text overflown in LinksHub intro columns

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,7 +65,7 @@ const RatingForkComponent: React.FC<RatingForkProps> = ({
 
   return (
     <div
-      className={`dark:text-white rounded-lg md:w-[160px] text-3xl p-4 dark:bg-[rgba(255,255,255,0.1)] bg-[rgba(0,0,0,0.05)] w-full`}
+      className={`dark:text-white rounded-lg md:w-[200px] text-3xl p-4 dark:bg-[rgba(255,255,255,0.1)] bg-[rgba(0,0,0,0.05)] w-full`}
     >
       {type === 'star' ? (
         <Icons.ioStar


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 

This PR is relevant with addressing Issue #2537. 

## Changes proposed

Suggest updating the width size of both columns in LinksHub intro. 

After testing in the 4 different screen sizes, including small, medium, large, x-large, of devices, the modified width could avoid text overflown. 

The columns also looked aligned after updated. 

## Screenshots

![Screenshot 2024-10-19 at 9 33 09 PM](https://github.com/user-attachments/assets/3f7546ca-6a33-490b-865c-396c2e715a6f)
