### PR TITLE
chore: added new resource for the css sub-category

### DIFF
--- a/database/languages/css.json
+++ b/database/languages/css.json
@@ -48,11 +48,11 @@
     "language": "hindi"
   },
   {
-    "name":"CSS-Tricks",
-    "description":"CSS-Tricks is a leading web development resource offering tutorials and articles focused on CSS, as well as other front-end topics like HTML, JavaScript, and design. Known for its practical solutions and community-driven forum, it's a go-to site for developers of all levels.",
-    "url":"https://css-tricks.com/",
-    "category":"languages",
-    "subcategory":"css",
-    "language":"english"
-   }
+    "name": "CSS-Tricks",
+    "description": "CSS-Tricks is a leading web development resource offering tutorials and articles focused on CSS, as well as other front-end topics like HTML, JavaScript, and design. Known for its practical solutions and community-driven forum, it's a go-to site for developers of all levels.",
+    "url": "https://css-tricks.com/",
+    "category": "languages",
+    "subcategory": "css",
+    "language": "english"
+  }
 ]

--- a/database/languages/css.json
+++ b/database/languages/css.json
@@ -52,6 +52,7 @@
     "description":"CSS-Tricks is a leading web development resource offering tutorials and articles focused on CSS, as well as other front-end topics like HTML, JavaScript, and design. Known for its practical solutions and community-driven forum, it's a go-to site for developers of all levels.",
     "url":"https://css-tricks.com/",
     "category":"languages",
-    "subcategory":"css"
+    "subcategory":"css",
+    "language":"english"
    }
 ]

--- a/database/languages/css.json
+++ b/database/languages/css.json
@@ -46,5 +46,12 @@
     "category": "languages",
     "subcategory": "css",
     "language": "hindi"
-  }
+  },
+  {
+    "name":"CSS-Tricks",
+    "description":"CSS-Tricks is a leading web development resource offering tutorials and articles focused on CSS, as well as other front-end topics like HTML, JavaScript, and design. Known for its practical solutions and community-driven forum, it's a go-to site for developers of all levels.",
+    "url":"https://css-tricks.com/",
+    "category":"languages",
+    "subcategory":"css"
+   }
 ]


### PR DESCRIPTION
## Fixes Issue

Fixes #2546 

## Changes proposed

Adds the following to the css.json file in "database/languages/"  folder

`"name":"CSS-Tricks",
    "description":"CSS-Tricks is a leading web development resource offering tutorials and articles focused on CSS, as well as other front-end topics like HTML, JavaScript, and design. Known for its practical solutions and community-driven forum, it's a go-to site for developers of all levels.",
    "url":"https://css-tricks.com/",
    "category":"languages",
    "subcategory":"css",
"language":"English"`
## Screenshots

None

## Note to reviewers
