### PR TITLE
feat: add overleaf as a new link under <Technical Writing/Technical Writing Tool>

### DIFF
--- a/database/technical-writing/tools.json
+++ b/database/technical-writing/tools.json
@@ -19,5 +19,12 @@
     "url": "https://hemingwayapp.com/",
     "category": "technical-writing",
     "subcategory": "technical_writing_tools"
+  },
+  {
+    "name": "Overleaf",
+    "description": "An online LaTeX editing platform with a real-time compiler. It allows users to collaborate on LaTeX projects seamlessly, making it easy to share and co-edit documents online. Overleaf also offers a wide range of templates for formal letters, resumes, technical articles, and more, helping users get started quickly.",
+    "url": "https://www.overleaf.com/",
+    "category": "technical-writing",
+    "subcategory": "technical_writing_tools"
   }
 ]


### PR DESCRIPTION
## Fixes Issue

Closes #2574

## Changes proposed

append new object for link in database/technical-writing/tools.json

## Screenshots

![image](https://github.com/user-attachments/assets/aedda8e3-1ecf-4419-9fed-3cf1bee18113)