### PR TITLE
feat: Added DevOps Engineer Roadmap

### DIFF
--- a/database/data.ts
+++ b/database/data.ts
@@ -1,9 +1,19 @@
+interface IDBData {
+  id: string;
+  name: string;
+  description: string;
+  url: string;
+  category: string;
+  subcategory: string;
+  language?: string; // Optional properties are marked with `?`
+}
 import { IDBData, IData, ISidebar } from '../types'
-import * as DB from 'database'
-import { v4 as uuidv4 } from 'uuid'
+import * as DB from 'database';
+import { v4 as uuidv4 } from 'uuid'; 
 export const database: IData[][] = Object.values(DB).map((item: IDBData[]) =>
   item.map((subcat: IDBData) => ({ ...subcat, id: uuidv4() }))
 )
+
 export const sidebarData: ISidebar[] = [
   {
     category: 'frontend',

--- a/database/data.ts
+++ b/database/data.ts
@@ -7,6 +7,7 @@ interface IDBData {
   subcategory: string;
   language?: string; // Optional properties are marked with `?`
 }
+import { IDBData } from '../types/IDBData'
 import { IDBData, IData, ISidebar } from '../types'
 import * as DB from 'database';
 import { v4 as uuidv4 } from 'uuid'; 

--- a/database/other/roadmaps.json
+++ b/database/other/roadmaps.json
@@ -40,5 +40,11 @@
     "url": "https://takeuforward.org/interviews/most-trusted-90-days-roadmap-to-placement-guaranteed/",
     "category": "other",
     "subcategory": "roadmaps"
+},
+{
+  "title": "DevOps Engineer Roadmap",
+  "description": "Comprehensive guide for becoming a DevOps Engineer, covering CI/CD, cloud, monitoring, and more.",
+  "link": "https://roadmap.sh/devops",
+  "type": "roadmap"
 }
 ]

--- a/database/src/types/IDBData.ts
+++ b/database/src/types/IDBData.ts
@@ -1,0 +1,9 @@
+export interface IDBData {
+  id: string;
+  name: string;
+  description: string;
+  url: string;
+  category: string;
+  subcategory: string;
+  language?: string; 
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 
This PR adds a new roadmap for DevOps Engineer, enhancing the Roadmaps section with a comprehensive guide for aspiring DevOps professionals.

## Changes proposed 
Added DevOps Engineer Roadmap to the Roadmaps section.
Included key details such as:
Title: DevOps Engineer Roadmap
Description: Comprehensive guide for becoming a DevOps Engineer, covering CI/CD, cloud technologies, monitoring, and more.
Link: https://roadmap.sh/devops

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers 
This roadmap is sourced from roadmap.sh, a well-known resource for developer roadmaps. It provides valuable insights for those looking to start or advance their journey in DevOps. Please review and suggest improvements if needed.