### PR TITLE
Add hamburger and chevron icons for sidebar toggle on mobile devices

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useContext, useState } from 'react'
 import Link from 'next/link'
 import clsx from 'clsx'
 import { useRouter } from 'next/router'
@@ -8,6 +8,7 @@ import Button from 'components/Button'
 
 import Logo from 'assets/logo.svg'
 import { Icons } from 'components/icons'
+import { GlobalContext } from 'context/GlobalContext'
 
 export const Header: FC = () => {
   const router = useRouter()
@@ -62,6 +63,7 @@ export const Header: FC = () => {
     }
   ]
 
+  const { toggleNav } = useContext(GlobalContext);
   const renderLinks = () =>
     navLinks.map(({ inActiveIcon, activeIcon, label, href }, i) => {
       const checkRoute = (val: string) => router.asPath.startsWith(val)
@@ -71,25 +73,32 @@ export const Header: FC = () => {
       const isActive = label === 'Home' ? isHomeActive : isUrlMatched
 
       return (
-          <li key={i}>
-            <a
-              href={href}
-              className={`hover:bg-slate-100 hover:bg-opacity-50 dark:hover:bg-zinc-400 dark:hover:bg-opacity-10 flex items-center justify-start p-2 gap-2 text-base font-medium leading-5 rounded-xl ${
-                isActive ? 'text-primary dark:text-white' : 'text-gray-text'
+        <li key={i}>
+          <a
+            href={href}
+            className={`hover:bg-slate-100 hover:bg-opacity-50 dark:hover:bg-zinc-400 dark:hover:bg-opacity-10 flex items-center justify-start p-2 gap-2 text-base font-medium leading-5 rounded-xl ${
+              isActive ? 'text-primary dark:text-white' : 'text-gray-text'
               }`}
-            >
-              <span className="flex items-center justify-center" title={label}>
-                {isActive ? activeIcon : inActiveIcon}
-              </span>
-              <span>{label}</span>
-            </a>
-          </li>
+          >
+            <span className="flex items-center justify-center" title={label}>
+              {isActive ? activeIcon : inActiveIcon}
+            </span>
+            <span>{label}</span>
+          </a>
+        </li>
       )
     })
 
   return (
     <header className="fixed top-0 left-0 z-30 row-start-1 row-end-2 h-[76px] w-screen flex items-center justify-between px-6 bg-white dark:bg-slate-800 shadow-header dark:shadow-none">
       <div className="flex gap-4 tall:gap-6">
+        {/* Mobile/Tablet Sidebar Toggle Button */}
+        <button
+          onClick={toggleNav}
+          className="sm:hidden text-gray-700 dark:text-white p-2 focus:outline-none"
+        >
+          <Icons.faAlignJustify className="h-6 w-6" />
+        </button>
         <Link href="/" aria-label="LinksHub Logo">
           <Logo />
         </Link>

--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, Ref } from 'react'
+import { useRef, useEffect, Ref, useContext } from 'react'
 import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
 
@@ -107,6 +107,7 @@ export const Searchbar: React.FC<SearchbarProps> = ({
 
   return (
     <form
+      style={{ width: "100%" }}
       data-custom="restrict-click-outside"
       noValidate
       ref={formRef}

--- a/components/SideNavbar/SideNavbarBody.tsx
+++ b/components/SideNavbar/SideNavbarBody.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, FC } from 'react'
+import { memo, useRef, FC, useContext } from 'react'
 
 import { Searchbar } from 'components/Searchbar/Searchbar'
 import { SideNavbarCategoryList } from 'components/SideNavbar/SideNavbarCategoryList'
@@ -6,8 +6,11 @@ const MemoizedSideNavbarCategoryList = memo(SideNavbarCategoryList)
 
 import { useSearchReducer } from 'hooks/useSearchReducer'
 import useSearchShortcut from 'hooks/useSearchShortcut'
+import { Icons } from 'components/icons'
+import { GlobalContext } from 'context/GlobalContext'
 
 const SideNavbarBody: FC = () => {
+  const { toggleNav } = useContext(GlobalContext);
   const inputRef: React.RefObject<HTMLInputElement> = useRef(null)
   useSearchShortcut({ inputRef })
 
@@ -15,12 +18,21 @@ const SideNavbarBody: FC = () => {
 
   return (
     <div className="fixed top-0 left-0 w-full h-[calc(100vh-80px)] flex flex-col items-start px-6 py-4  gap-4 tall:gap-10 bg-white dark:bg-[#161E2C] shadow-sidebar dark:shadow-none">
-      <div className="w-full flex flex-col gap-4 tall:gap-6">
+      <div className="w-full flex tall:gap-6">
         <Searchbar
           inputRef={inputRef}
           {...searchState}
           dispatchSearch={dispatchSearch}
         />
+
+        <button
+          style={{ marginLeft: "auto" }}
+          onClick={toggleNav}
+          className="sm:hidden text-gray-700 dark:text-white p-2 focus:outline-none"
+        >
+          <Icons.faChevronLeft className="h-6 w-6" />
+        </button>
+
       </div>
 
       <div className="w-full max-h-[calc(100vh-190px)] h-full flex flex-col items-between gap-2 tall:gap-5">

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -13,6 +13,7 @@ import {
   FaHeart,
   FaLinkedin,
   FaTrophy,
+  FaAlignJustify,
 } from 'react-icons/fa'
 import {
   FaDiscord,
@@ -20,9 +21,12 @@ import {
   FaXTwitter,
   FaArrowRightLong,
   FaStaylinked,
+  FaChevronLeft
 } from 'react-icons/fa6'
 
 export const Icons = {
+  faAlignJustify: FaAlignJustify,
+  faChevronLeft: FaChevronLeft,
   arrowRoundForward: IoIosArrowRoundForward,
   arrowBack: IoIosArrowBack,
   gitBranch: IoMdGitBranch,


### PR DESCRIPTION
## Changes proposed

This PR introduces a hamburger icon and a chevron icon for toggling the sidebar specifically on mobile devices.

Key Changes:

1. Added a hamburger icon to open the sidebar.
2. Added a chevron icon for closing the sidebar.
3. Ensured the functionality works smoothly on mobile devices, improving the user experience.
4. Tested for responsiveness and compatibility.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![Screenshot 1](https://github.com/user-attachments/assets/9a69d36c-9c49-4c9e-b7ea-452ab47d0263)
![Screenshot 2](https://github.com/user-attachments/assets/062b3d98-d0b7-45d5-afab-479ee70236bb)

![Screenshot 3](https://github.com/user-attachments/assets/45dbcde5-d7fe-4e14-b17e-9e90d715616c)
![Screenshot  4](https://github.com/user-attachments/assets/c238bdf9-a8ef-4817-9a1f-8a374c5e116f)
