### PR TITLE
fix: Change search suggestion name 'react' to 'react articles' (#2590)

### DIFF
--- a/database/data.ts
+++ b/database/data.ts
@@ -378,7 +378,7 @@ export const sidebarData: ISidebar[] = [
     category: 'tech-articles',
     subcategory: [
       {
-        name: 'react',
+        name: 'react articles',
         url: '/react_articles',
         resources: DB.reactArticles,
       },


### PR DESCRIPTION
## Fixes Issue

Closes #2590 

## Changes proposed

Updated search suggestion object data name "react" with "react articles" in the database / data.ts

## Screenshots

![Screenshot from 2024-12-10 10-52-01](https://github.com/user-attachments/assets/529befb9-0200-4cd6-ba63-c34b656f79a2)

