### PR TITLE
docs: Add Algomap.io to DSA Articles

### DIFF
--- a/components/SideNavbar/SideNavbarCategoryList.tsx
+++ b/components/SideNavbar/SideNavbarCategoryList.tsx
@@ -11,7 +11,7 @@ export const SideNavbarCategoryList: FC<{
   const router = useRouter()
   const [category, setCategory] = useState<string | undefined>('')
   const listRef = useRef<HTMLUListElement | null>(null)
-
+                               
   useEffect(() => {
     const cat: string | undefined = router.query.category as string | undefined
 

--- a/database/data_structures/dsa_articles.json
+++ b/database/data_structures/dsa_articles.json
@@ -12,5 +12,12 @@
     "url": "https://cheatography.com/burcuco/cheat-sheets/data-structures-and-algorithms/",
     "category": "data-structures",
     "subcategory": "dsa_articles"
+  },
+  {
+    "name": "Free DSA RoadMap",
+    "description": "Its a free DSA roadmap which consists of topic wise problems along with video and code solutions ,it's a great website for getting started",
+    "url": "https://algomap.io/",
+    "category": "data-structures",
+    "subcategory": "dsa_articles"
   }
 ]


### PR DESCRIPTION



Description:
Added a link to Algomap.io under the DSA Articles section in the Data Structures category. This provides users with an additional resource for exploring DSA concepts interactively.

Changes Made:
Added Algomap.io link in the DSA Articles section.
Testing:
✅ Verified that the link is correctly added and working as expected.

