### PR TITLE
chore: added DevOps subcategory in the newsletter category

### DIFF
--- a/components/TopBar/CategoryDescriptions.ts
+++ b/components/TopBar/CategoryDescriptions.ts
@@ -304,6 +304,7 @@ const categoryDescriptions: CategoryDescriptions = {
   // tech articles
   react_articles:
     'Get the best articles for react to improve your skills and knowledge.',
+    
   // newsletters
   jsLetters:
     'It covers the latest updates, trends, and resources in the JavaScript ecosystem, keeping developers informed and engaged.',
@@ -311,6 +312,8 @@ const categoryDescriptions: CategoryDescriptions = {
     'It covers the latest updates, trends, and resources in the Python ecosystem.',
   javaLetters:
     'It covers the latest updates, trends, and resources in the Java ecosystem.',
+  devopsLetters:
+    'It covers the latest updates, trends, and resources in the DevOps ecosystem.',
 }
 
 export default categoryDescriptions

--- a/database/data.ts
+++ b/database/data.ts
@@ -403,6 +403,11 @@ export const sidebarData: ISidebar[] = [
         url: '/javaLetters',
         resources: DB.javaLetters,
       },
+      { 
+        name: 'devops',
+        url: '/devopsletter',
+        resources: DB.devopsletter,
+      }
     ],
   },
   {

--- a/database/data.ts
+++ b/database/data.ts
@@ -406,7 +406,7 @@ export const sidebarData: ISidebar[] = [
       { 
         name: 'devops',
         url: '/devopsletter',
-        resources: DB.devopsletter,
+        resources: DB.devopsLetters,
       }
     ],
   },

--- a/database/data.ts
+++ b/database/data.ts
@@ -405,7 +405,7 @@ export const sidebarData: ISidebar[] = [
       },
       { 
         name: 'devops',
-        url: '/devopsletter',
+        url: '/devopsLetters',
         resources: DB.devopsLetters,
       }
     ],

--- a/database/index.ts
+++ b/database/index.ts
@@ -168,6 +168,8 @@ export { default as reactArticles } from './tech_articles/react.json'
 export { default as jsLetters } from './newsletters/js_Letters.json'
 export { default as pythonLetters } from './newsletters/py_Letters.json'
 export { default as javaLetters } from './newsletters/java_Letters.json'
+export { default as devopsLetters } from './newsletters/devops.json'
+
 // Ethical Hacking
 export { default as cryptographyAttacks } from './ethical_hacking/cryptography_attacks.json'
 export { default as malwareAndPayloadDevelopment } from './ethical_hacking/malware_and_payload_development.json'

--- a/database/newsletters/devops.json
+++ b/database/newsletters/devops.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "GitHub",
+        "description": "Get tips, technical guides, and best practices. Twice a month. Right in your inbox.",
+        "url": "https://resources.github.com/newsletter/",
+        "category": "newsletters",
+        "subcategory": "devopsLetters"
+    },{
+        "name": "Docker",
+        "description": "The Docker Newsletter is your essential resource, curated for Docker users like you. Keep your finger on the pulse of the Docker ecosystem.",
+        "url": "https://www.docker.com/newsletter-subscription/",
+        "category": "newsletters",
+        "subcategory": "devopsLetters"
+    },{
+        "name": "Kubernetes",
+        "description": "The Kubernetes Newsletter is a monthly newsletter that delivers the hottest Kubernetes news, articles, events, and more.",
+        "url": "https://www.cncf.io/kubeweekly/",
+        "category": "newsletters",
+        "subcategory": "devopsLetters"
+    }
+]

--- a/database/newsletters/devops.json
+++ b/database/newsletters/devops.json
@@ -1,21 +1,23 @@
 [
-    {
-        "name": "GitHub",
-        "description": "Get tips, technical guides, and best practices. Twice a month. Right in your inbox.",
-        "url": "https://resources.github.com/newsletter/",
-        "category": "newsletters",
-        "subcategory": "devopsLetters"
-    },{
-        "name": "Docker",
-        "description": "The Docker Newsletter is your essential resource, curated for Docker users like you. Keep your finger on the pulse of the Docker ecosystem.",
-        "url": "https://www.docker.com/newsletter-subscription/",
-        "category": "newsletters",
-        "subcategory": "devopsLetters"
-    },{
-        "name": "Kubernetes",
-        "description": "The Kubernetes Newsletter is a monthly newsletter that delivers the hottest Kubernetes news, articles, events, and more.",
-        "url": "https://www.cncf.io/kubeweekly/",
-        "category": "newsletters",
-        "subcategory": "devopsLetters"
-    }
+	{
+		"name": "GitHub",
+		"description": "Get tips, technical guides, and best practices. Twice a month. Right in your inbox.",
+		"url": "https://resources.github.com/newsletter/",
+		"category": "newsletters",
+		"subcategory": "devopsLetters"
+	},
+	{
+		"name": "Docker",
+		"description": "The Docker Newsletter is your essential resource, curated for Docker users like you. Keep your finger on the pulse of the Docker ecosystem.",
+		"url": "https://www.docker.com/newsletter-subscription/",
+		"category": "newsletters",
+		"subcategory": "devopsLetters"
+	},
+	{
+		"name": "Kubernetes",
+		"description": "The Kubernetes Newsletter is a monthly newsletter that delivers the hottest Kubernetes news, articles, events, and more.",
+		"url": "https://www.cncf.io/kubeweekly/",
+		"category": "newsletters",
+		"subcategory": "devopsLetters"
+	}
 ]


### PR DESCRIPTION
Fixes #2627

## Fixes Issue #2627 

## Changes proposed

<!-- List all the proposed changes in your PR -->
- Added a new subcategory "devopsLetters" under the "newsletters" category in the `devops.json` file.
- Included three DevOps-related newsletters: GitHub, Docker, and Kubernetes.
- Updated `file.ts` to include the new `devopsLetters` export.
- Updated `data.ts` to include the new `devopsLetters` subcategory under the "newsletters" category.