### PR TITLE
feat: Move alphabetical sorting to the subcategory level from the CardsList

### DIFF
--- a/components/Cards/CardsList.tsx
+++ b/components/Cards/CardsList.tsx
@@ -15,8 +15,6 @@ const CardsList: FC<{ cards: IData[] }> = ({ cards }) => {
     setCurrentCard(null)
   }
 
-  cards.sort((a: IData, b: IData) => a.name.localeCompare(b.name))
-
   return (
     <>
       <ul className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 justify-items-stretch ">

--- a/pages/[category]/[...subcategory].tsx
+++ b/pages/[category]/[...subcategory].tsx
@@ -10,6 +10,7 @@ import { ParsedUrlQuery } from 'querystring'
 import { usePagination } from 'hooks/usePagination'
 import Pagination from 'components/Pagination/Pagination'
 import { ReportBug } from 'components/ReportBug/Reportbug'
+import type { IData } from 'types'
 
 interface PageProps {
   category: string
@@ -24,15 +25,21 @@ const SubCategory: NextPage<PageProps> = ({ subcategory }) => {
     pageCategory[0].toUpperCase() + pageCategory.slice(1)
   }`
 
-  const numberOfCards = filterDB[0].length
+  const sortedData = filterDB.length
+    ? [...filterDB[0]].sort((a: IData, b: IData) =>
+        a.name.localeCompare(b.name)
+      )
+    : []
+
+  const numberOfCards = sortedData.length
 
   const { totalPages, currentPage, startIndex, endIndex, handlePageChange } =
-    usePagination(filterDB.length ? filterDB[0].length : 0)
+    usePagination(sortedData.length)
   let content: JSX.Element[] | JSX.Element
   let filterData
 
-  if (filterDB && filterDB.length > 0) {
-    filterData = filterDB[0].slice(startIndex, endIndex)
+  if (sortedData.length > 0) {
+    filterData = sortedData.slice(startIndex, endIndex)
     content = <CardsList cards={filterData} />
   } else {
     content = <ComingSoon />


### PR DESCRIPTION
## Fixes Issue

Closes #2674 

## Changes proposed

This PR improves the cards sorting in subcategories by moving the sorting logic from CardsList to the subcategory level. This allows continuous alphabetical pagination across multiple subcategory pages.

These changes ensure consistent data presentation and improve user experience.

## Screenshots

![image](https://github.com/user-attachments/assets/d39f67d1-c761-47d7-8afe-8768f6aaa6e3)
![image](https://github.com/user-attachments/assets/8f5b8bd7-2772-4c53-9565-a8b1fea18080)
