### PR TITLE
fix: Correct typo in Monitoring And Logging subcategory (#2713)

### DIFF
--- a/database/data.ts
+++ b/database/data.ts
@@ -261,7 +261,7 @@ export const sidebarData: ISidebar[] = [
         resources: DB.microservices,
       },
       {
-        name: 'Monitoring and Loggging',
+        name: 'Monitoring and Logging',
         url: '/monitoring_and_logging',
         resources: DB.monitorLogging,
       },


### PR DESCRIPTION
## Fixes Issue

Closes #2713 

## Changes proposed

- Fixed a typo in the "Monitoring And Logging" subcategory name where "Logging" was misspelled as "Loggging".