### PR TITLE
chore: add Website Uptime Monitor

### DIFF
--- a/database/devops/monitoring_and_logging.json
+++ b/database/devops/monitoring_and_logging.json
@@ -5,5 +5,12 @@
     "url": "https://sensu.io/",
     "category": "devops",
     "subcategory": "monitoring_and_logging"
+  },
+  {
+    "name": "Website Uptime Monitor",
+    "description": "An open-source GitHub Action that monitors websites' uptime, logs results, and creates issues when sites are down. All managed entirely within your GitHub repository, with no external servers or cloud services required.",
+    "url": "https://github.com/marketplace/actions/website-uptime-monitor",
+    "category": "devops",
+    "subcategory": "monitoring_and_logging"
   }
 ]


### PR DESCRIPTION
## Fixes Issue

Closes #2718 

## Changes proposed

Add Website Uptime Monitor to DevOps / Monitoring and Logging

## Screenshots

<img width="517" height="294" alt="image" src="https://github.com/user-attachments/assets/6889853b-3b24-4daf-b44c-41403c020567" />