### PR TITLE
fix: closes searchbar dropdown when clicking outside

### DIFF
--- a/components/Searchbar/Searchbar.tsx
+++ b/components/Searchbar/Searchbar.tsx
@@ -105,25 +105,21 @@ export const Searchbar: React.FC<SearchbarProps> = ({
 
   useEffect(() => {
     const handleClickOutsideDropdown = (e: MouseEvent) => {
-      if (
-        e.target &&
-        (e.target as HTMLElement).closest(
-          "[data-custom='restrict-click-outside']"
-        ) !== null
-      ) {
+      if (!e.target) return
+      
+      if (formRef.current && formRef.current.contains(e.target as Node)) {
         return
       }
-      if ((formRef.current as HTMLFormElement).contains(e.target as Node))
-        return
+      
       dispatchSearch({ type: 'close_suggestions' })
     }
 
-    document.addEventListener('mousedown', handleClickOutsideDropdown)
+    document.addEventListener('mousedown', handleClickOutsideDropdown, true)
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutsideDropdown)
+      document.removeEventListener('mousedown', handleClickOutsideDropdown, true)
     }
-  }, [dispatchSearch])
+  }, [])
 
   return (
     <form


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->
<!-- Example: Closes #31 -->
Closes #2720 

## Changes proposed

<!-- List all the proposed changes in your PR -->
- Refactor Searchbar handleClickOutsideDropdown to close regardless of "restrict-click-outside" as it's supposed to close when the user clicks outside the input.
- Adds "true" as 3rd param of addEventListener to fire handleClickOutsideDropdown on capture phase.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
This closes the dropdown everytime the user clicks in a place that's not the input itself.