### PR TITLE
feat: Add FlowiseAI link (#2758)

### DIFF
--- a/database/ai_tools/chat_bots.json
+++ b/database/ai_tools/chat_bots.json
@@ -68,5 +68,13 @@
     "url": "https://www.perplexity.ai/",
     "category": "ai-tools",
     "subcategory": "chat_bots"
-  }
+  },
+  {
+        "name": "FlowiseAI",
+        "description": "Open source UI visual tool to build your customized LLM flow using LangchainJS.",
+        "url": "https://flowiseai.com/",
+        "category": "ai",
+        "subcategory": "chatbot",
+        "language": "JavaScript"
+    }
 ]


### PR DESCRIPTION
## Fixes Issue
Closes #2758

## Changes proposed
Added FlowiseAI link to the AI Chatbots category in database/ai_tools/chat_bots.json.

## Screenshots
N/A

## Note to reviewers
I have followed the contributing guidelines and added the link in the correct JSON format.