### PR TITLE
feat: add Baeldung resource to spring boot

### DIFF
--- a/database/backend_frameworks/spring_boot.json
+++ b/database/backend_frameworks/spring_boot.json
@@ -6,5 +6,13 @@
       "category": "backend-frameworks",
       "subcategory": "spring_boot",
       "language": "english"
+    },
+    {
+      "name": "Baeldung Spring Boot",
+      "description": "Comprehensive Spring Boot tutorials covering basics, advanced topics, and practical examples.",
+      "url": "https://www.baeldung.com/spring-boot",
+      "category": "backend-frameworks",
+      "subcategory": "spring_boot",
+      "language": "english"
     }
 ]


### PR DESCRIPTION
## New Feature added 
## Changes proposed
I added the "Baeldung Spring Boot" tutorials to the Backend Frameworks > Spring Boot category. It is a highly rated resource for learning Spring Boot.

## Screenshots
<img width="1910" height="826" alt="Screenshot 2025-12-31 223423" src="https://github.com/user-attachments/assets/781adc4e-5952-4435-a95c-72767969381e" />

## Note to reviewers
This is my first contribution to LinksHub!